### PR TITLE
Fix round timer

### DIFF
--- a/src/blockdata.rs
+++ b/src/blockdata.rs
@@ -77,10 +77,11 @@ impl Block {
 
     /// Returns hash for signing. This hash value doesn't include proof field. Actual block hash
     /// includes proof data.
-    pub fn sighash(&self) -> Result<hash::Hash, Error> {
+    pub fn sighash(&self) -> hash::Hash {
         let header = self.get_header_without_proof();
         let hash = sha256d::Hash::hash(header).into_inner();
-        Ok(hash::Hash::from_slice(&hash)?)
+        hash::Hash::from_slice(&hash)
+            .expect("couldn't convert to blockdata::hash::Hash from sha256d::hash")
     }
 
     /// Returns block hash
@@ -164,7 +165,7 @@ mod tests {
     #[test]
     fn test_block_hash_debug_fmt() {
         let block = test_block();
-        let hash = block.sighash().unwrap();
+        let hash = block.sighash();
 
         assert_eq!(
             format!("{:?}", hash),

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -663,7 +663,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                     new_signatures.len(),
                     self.params.threshold
                 );
-                if candidate_block.hash().unwrap() != blockhash {
+                if candidate_block.sighash().unwrap() != blockhash {
                     log::error!("Invalid blockvss message received. Received message is based different block. expected: {:?}, actual: {:?}", candidate_block.sighash().unwrap(), blockhash);
                     return self.start_next_round(false);
                 }

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -129,7 +129,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             current_state: NodeState::Joining,
             stop_signal: None,
             master_index: 0,
-            round_timer: RoundTimeOutObserver::new(timer_limit),
+            round_timer: RoundTimeOutObserver::new("round_timer", timer_limit),
             priv_shared_keys: None,
             shared_secrets: BTreeMap::new(),
         }

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -755,15 +755,10 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                             log::info!(
                                 "Round Success. caindateblock(block hash for sign)={:?} completedblock={:?}",
                                 candidate_block.sighash(),
-                                new_block.hash().expect("Can't get block hash")
+                                new_block.hash()
                             );
                             // send completeblock message
-                            log::info!(
-                                "Broadcast CompletedBlock message. {:?}",
-                                new_block
-                                    .hash()
-                                    .expect("Can't get block hash from completed block")
-                            );
+                            log::info!("Broadcast CompletedBlock message. {:?}", new_block.hash());
                             let message = Message {
                                 message_type: MessageType::Completedblock(new_block),
                                 sender_id: self.params.signer_id.clone(),

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -27,7 +27,7 @@ use crate::util::*;
 /// Round interval.
 pub static ROUND_INTERVAL_DEFAULT_SECS: u64 = 60;
 /// Round time limit delta. Round timeout timer should be little longer than `ROUND_INTERVAL_DEFAULT_SECS`.
-static ROUND_TIMELIMIT_DELTA: u64 = 5;
+static ROUND_TIMELIMIT_DELTA: u64 = 10;
 
 pub struct SignerNode<T: TapyrusApi, C: ConnectionManager> {
     connection_manager: C,
@@ -923,7 +923,7 @@ mod tests {
     use crate::rpc::tests::{safety, safety_error, MockRpc, SafetyBlock};
     use crate::rpc::TapyrusApi;
     use crate::signer_node::{BidirectionalSharedSecretMap, NodeParameters, NodeState, SignerNode};
-    use crate::test_helper::{get_block, TestKeys};
+    use crate::test_helper::{get_block, TestKeys, enable_log};
     use bitcoin::{Address, PrivateKey};
 
     type SpyMethod = Box<dyn Fn(Arc<Message>) -> () + Send + 'static>;
@@ -1207,6 +1207,7 @@ mod tests {
 
     #[test]
     fn test_timeout_roundrobin() {
+        enable_log(None);
         let closure: SpyMethod = Box::new(move |_message: Arc<Message>| {});
         let initial_state = NodeState::Member {
             block_key: None,
@@ -1227,7 +1228,7 @@ mod tests {
         assert_eq!(node.master_index, 0 as usize);
         let ss = stop_signal.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(6)); // 6s = 1 round (5s) + 1s
+            thread::sleep(Duration::from_secs(11)); // 11s = 1 round (10s) + 1s
             ss.send(1).unwrap();
         });
         node.start();

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -789,11 +789,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
     }
 
     fn create_node_share(&mut self) {
-        //Wait for completing redis connection.
-        thread::sleep(time::Duration::from_secs(10));
-
         let params = self.sharing_params();
-
         let key = Sign::create_key(
             self.params.self_node_index + 1,
             Sign::private_key_to_big_int(self.params.private_key.key),
@@ -1244,7 +1240,7 @@ mod tests {
         assert_eq!(node.master_index, 0 as usize);
         let ss = stop_signal.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(16));
+            thread::sleep(Duration::from_secs(6)); // 6s = 1 round (5s) + 1s
             ss.send(1).unwrap();
         });
         node.start();

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -394,6 +394,11 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
+    fn is_master(&self, sender_id: &SignerID) -> bool {
+        let master_id = self.params.pubkey_list[self.master_index];
+        master_id == sender_id.pubkey
+    }
+
     /// Start next round.
     /// decide master of next round according to Round-robin.
     fn start_next_round(&mut self, first_round: bool) -> NodeState {
@@ -430,7 +435,11 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         next_state
     }
     fn process_completedblock(&mut self, sender_id: &SignerID, _block: &Block) -> NodeState {
-        self.start_next_round(false)
+        if self.is_master(sender_id) {
+            self.start_next_round(false)
+        } else {
+            self.current_state.clone()
+        }
     }
 
     fn process_nodevss(


### PR DESCRIPTION
Fix round timer behavior. The timer behavior didn't have consistent policy. So, it worked inconsistent way.

After this PR, Round timer must follow below basically rule.

* The timer is started on rounds start only.
* New round is started on only receiving completedblock message or previous round is timeout.