### PR TITLE
Make signer node has idle time before starting Key Generation Protocol communication

### DIFF
--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -13,7 +13,7 @@ extern crate tapyrus_signer;
 use bitcoin::{PrivateKey, PublicKey};
 
 use daemonize::Daemonize;
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tapyrus_signer::command_args::{CommandArgs, RedisConfig, RpcConfig};
@@ -72,8 +72,17 @@ fn main() {
 
 fn daemonize(pid: &str, log_file: &str) {
     println!("Start Tapyrus Signer Daemon. pid file: {}", pid);
-    let stdout = File::create(log_file).unwrap();
-    let stderr = File::create(log_file).unwrap();
+    let stdout = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(log_file)
+        .expect(&format!("Couldn't open {}", log_file));
+
+    let stderr = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(log_file)
+        .expect(&format!("Couldn't open {}", log_file));
 
     let daemonize = Daemonize::new().pid_file(pid).stdout(stdout).stderr(stderr);
 

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -1266,7 +1266,7 @@ mod tests {
         assert_eq!(node.master_index, 0 as usize);
         let ss = stop_signal.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(16)); // 11s = 1 round (10s) + idle time(5s) + 1s
+            thread::sleep(Duration::from_secs(16)); // 16s = 1 round (10s) + idle time(5s) + 1s
             ss.send(1).unwrap();
         });
         node.start();

--- a/src/signer_node.rs
+++ b/src/signer_node.rs
@@ -167,6 +167,10 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         let _handler = self.connection_manager.start(closure, id);
 
         log::info!("Start Key generation Protocol");
+        // Idle 5s, before node starts Key Generation Protocol communication.
+        // To avoid that nodes which is late to startup can't receive messages.
+        log::info!("Idle 5 secs... ");
+        std::thread::sleep(Duration::from_secs(5));
         self.create_node_share();
 
         // Start First Round
@@ -1262,7 +1266,7 @@ mod tests {
         assert_eq!(node.master_index, 0 as usize);
         let ss = stop_signal.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(11)); // 11s = 1 round (10s) + 1s
+            thread::sleep(Duration::from_secs(16)); // 11s = 1 round (10s) + idle time(5s) + 1s
             ss.send(1).unwrap();
         });
         node.start();


### PR DESCRIPTION
This PR fixes #30

This PR also includes to make node process avoid to truncate log file when the process started.