### PR TITLE
Fix generating wrong signature.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,17 +141,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bulletproof"
-version = "0.2.0"
-source = "git+https://github.com/KZen-networks/bulletproofs?tag=v0.2.0#3bbbd2c9f55da3320cb2db3b5446059c830f28f8"
-dependencies = [
- "curv 0.2.0 (git+https://github.com/KZen-networks/curv?tag=v0.2.0)",
- "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,18 +163,6 @@ dependencies = [
 name = "cc"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "centipede"
-version = "0.2.0"
-source = "git+https://github.com/KZen-networks/centipede?tag=v0.2.0#bdfafaa26e64aa9cd3ac6db4efe3c3ac5db2e2fd"
-dependencies = [
- "bulletproof 0.2.0 (git+https://github.com/KZen-networks/bulletproofs?tag=v0.2.0)",
- "curv 0.2.0 (git+https://github.com/KZen-networks/curv?tag=v0.2.0)",
- "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cfg-if"
@@ -232,50 +209,10 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -447,14 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,14 +468,6 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "memoffset"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "merkle-sha3"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,17 +509,6 @@ dependencies = [
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "multi-party-schnorr"
-version = "0.3.0"
-source = "git+https://github.com/Yamaguchi/multi-party-schnorr?rev=cd92eecc736b7a48bd3a24284f3c3155c7f18179#cd92eecc736b7a48bd3a24284f3c3155c7f18179"
-dependencies = [
- "centipede 0.2.0 (git+https://github.com/KZen-networks/centipede?tag=v0.2.0)",
- "curv 0.2.0 (git+https://github.com/KZen-networks/curv?tag=v0.2.0)",
- "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -798,28 +708,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1051,10 +939,10 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multi-party-schnorr 0.3.0 (git+https://github.com/Yamaguchi/multi-party-schnorr?rev=cd92eecc736b7a48bd3a24284f3c3155c7f18179)",
  "redis 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1333,22 +1221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 "checksum boxfnonce 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-"checksum bulletproof 0.2.0 (git+https://github.com/KZen-networks/bulletproofs?tag=v0.2.0)" = "<none>"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
-"checksum centipede 0.2.0 (git+https://github.com/KZen-networks/centipede?tag=v0.2.0)" = "<none>"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
-"checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
-"checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-"checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
-"checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum curv 0.2.0 (git+https://github.com/KZen-networks/curv?tag=v0.2.0)" = "<none>"
 "checksum daemonize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -1369,7 +1251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-"checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jsonrpc 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "436f3455a8a4e9c7b14de9f1206198ee5d0bdc2db1b560339d2141093d7dd389"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
@@ -1383,12 +1264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum merkle-sha3 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5dd5529ec9d248c34cedc964ae0d9511c1efb700cd0121c61299cab95cea1868"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multi-party-schnorr 0.3.0 (git+https://github.com/Yamaguchi/multi-party-schnorr?rev=cd92eecc736b7a48bd3a24284f3c3155c7f18179)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "443c53b3c3531dfcbfa499d8893944db78474ad7a1d87fa2d94d1a2231693ac6"
 "checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
@@ -1411,8 +1290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
-"checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redis 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b543b95de413ac964ca609e91fd9fd58419312e69988fb197f3ff8770312a1af"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +869,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "sha2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha3"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +960,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1236,6 +1253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -1309,6 +1327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)" = "ca13fc1a832f793322228923fbb3aba9f3f44444898f835d31ad1b74fa0a2bf8"
 "checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+"checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum sha3 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd26bc0e7a2e3a7c959bc494caf58b72ee0c71d67704e9520f736ca7e4853ecf"
 "checksum signal-hook 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "7a9c17dd3ba2d36023a5c9472ecddeda07e27fd0b05436e8c1e0c8f178185652"
 "checksum signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ secp256k1 = "0.15.3"
 log = "0.4.6"
 env_logger = "0.6.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"
 serde_json = "1.0.39"
 bitcoin_hashes = "0.3.2"
 jsonrpc = "0.11.0"
@@ -21,7 +22,6 @@ base64 = "0.10.1"
 redis = "0.10.0"
 clap = "2.33.0"
 toml = "0.5"
-multi-party-schnorr = { git = "https://github.com/Yamaguchi/multi-party-schnorr", rev = "cd92eecc736b7a48bd3a24284f3c3155c7f18179" }
 curv = { git = "https://github.com/KZen-networks/curv" , tag = "v0.2.0", features =  ["ec_secp256k1"]}
 signal-hook = "0.1.12"
 libc = "0.2.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ redis = "0.10.0"
 clap = "2.33.0"
 toml = "0.5"
 curv = { git = "https://github.com/KZen-networks/curv" , tag = "v0.2.0", features =  ["ec_secp256k1"]}
+sha2 = "0.8.1"
 signal-hook = "0.1.12"
 libc = "0.2.66"
 daemonize = "0.4.1"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,4 @@
+pub mod multi_party_schnorr;
+
+#[cfg(test)]
+mod test_multi_party_schnorr;

--- a/src/crypto/multi_party_schnorr.rs
+++ b/src/crypto/multi_party_schnorr.rs
@@ -1,0 +1,293 @@
+/*
+    Multisig Schnorr
+
+    Copyright 2018 by Kzen Networks
+    Copyright 2020 by Chaintope Inc.
+
+    This file is copied from Multisig Schnorr library
+    (https://github.com/KZen-networks/multisig-schnorr)
+
+    Multisig Schnorr is free software: you can redistribute
+    it and/or modify it under the terms of the GNU General Public
+    License as published by the Free Software Foundation, either
+    version 3 of the License, or (at your option) any later version.
+
+    @license GPL-3.0+ <https://github.com/KZen-networks/multisig-schnorr/blob/master/LICENSE>
+*/
+/// following the variant used in bip-schnorr: https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
+use crate::errors::Error::{self, InvalidKey, InvalidSS, InvalidSig};
+
+use curv::arithmetic::traits::*;
+
+use curv::elliptic::curves::traits::*;
+
+use curv::cryptographic_primitives::commitments::hash_commitment::HashCommitment;
+use curv::cryptographic_primitives::commitments::traits::Commitment;
+use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
+use curv::cryptographic_primitives::hashing::traits::Hash;
+use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
+use curv::{BigInt, FE, GE};
+
+const SECURITY: usize = 256;
+
+pub struct Keys {
+    pub u_i: FE,
+    pub y_i: GE,
+    pub party_index: usize,
+}
+
+pub struct KeyGenBroadcastMessage1 {
+    com: BigInt,
+}
+
+#[derive(Debug)]
+pub struct Parameters {
+    pub threshold: usize,   //t
+    pub share_count: usize, //n
+}
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SharedKeys {
+    pub y: GE,
+    pub x_i: FE,
+}
+
+impl Keys {
+    pub fn phase1_create(index: usize) -> Keys {
+        let u: FE = ECScalar::new_random();
+        let y = &ECPoint::generator() * &u;
+
+        Keys {
+            u_i: u,
+            y_i: y,
+            party_index: index.clone(),
+        }
+    }
+
+    pub fn phase1_broadcast(&self) -> (KeyGenBroadcastMessage1, BigInt) {
+        let blind_factor = BigInt::sample(SECURITY);
+        let com = HashCommitment::create_commitment_with_user_defined_randomness(
+            &self.y_i.bytes_compressed_to_big_int(),
+            &blind_factor,
+        );
+        let bcm1 = KeyGenBroadcastMessage1 { com };
+        (bcm1, blind_factor)
+    }
+
+    pub fn phase1_verify_com_phase2_distribute(
+        &self,
+        params: &Parameters,
+        blind_vec: &Vec<BigInt>,
+        y_vec: &Vec<GE>,
+        bc1_vec: &Vec<KeyGenBroadcastMessage1>,
+        parties: &[usize],
+    ) -> Result<(VerifiableSS, Vec<FE>, usize), Error> {
+        // test length:
+        assert_eq!(blind_vec.len(), params.share_count);
+        assert_eq!(bc1_vec.len(), params.share_count);
+        assert_eq!(y_vec.len(), params.share_count);
+        // test decommitments
+        let correct_key_correct_decom_all = (0..bc1_vec.len())
+            .map(|i| {
+                HashCommitment::create_commitment_with_user_defined_randomness(
+                    &y_vec[i].bytes_compressed_to_big_int(),
+                    &blind_vec[i],
+                ) == bc1_vec[i].com
+            })
+            .all(|x| x == true);
+        /*
+        let (vss_scheme, secret_shares) = VerifiableSS::share_at_indices(
+            params.threshold,
+            params.share_count,
+            &self.u_i,
+            parties,
+        );
+        */
+        let (vss_scheme, secret_shares) = VerifiableSS::share_at_indices(
+            params.threshold,
+            params.share_count,
+            &self.u_i,
+            &parties,
+        );
+
+        match correct_key_correct_decom_all {
+            true => Ok((vss_scheme, secret_shares, self.party_index.clone())),
+            false => Err(InvalidKey),
+        }
+    }
+
+    pub fn phase2_verify_vss_construct_keypair(
+        &self,
+        params: &Parameters,
+        y_vec: &Vec<GE>,
+        secret_shares_vec: &Vec<FE>,
+        vss_scheme_vec: &Vec<VerifiableSS>,
+        index: &usize,
+    ) -> Result<SharedKeys, Error> {
+        assert_eq!(y_vec.len(), params.share_count);
+        assert_eq!(secret_shares_vec.len(), params.share_count);
+        assert_eq!(vss_scheme_vec.len(), params.share_count);
+
+        let correct_ss_verify = (0..y_vec.len())
+            .map(|i| {
+                vss_scheme_vec[i]
+                    .validate_share(&secret_shares_vec[i], *index)
+                    .is_ok()
+                    && vss_scheme_vec[i].commitments[0] == y_vec[i]
+            })
+            .all(|x| x == true);
+
+        match correct_ss_verify {
+            true => {
+                let mut y_vec_iter = y_vec.iter();
+                let y0 = y_vec_iter.next().unwrap();
+                let y = y_vec_iter.fold(y0.clone(), |acc, x| acc + x);
+                let x_i = secret_shares_vec.iter().fold(FE::zero(), |acc, x| acc + x);
+                Ok(SharedKeys { y, x_i })
+            }
+            false => Err(InvalidSS),
+        }
+    }
+
+    // remove secret shares from x_i for parties that are not participating in signing
+    pub fn update_shared_key(
+        shared_key: &SharedKeys,
+        parties_in: &[usize],
+        secret_shares_vec: &Vec<FE>,
+    ) -> SharedKeys {
+        let mut new_xi: FE = FE::zero();
+        for i in 0..secret_shares_vec.len() {
+            if parties_in.iter().find(|&&x| x == i).is_some() {
+                new_xi = new_xi + &secret_shares_vec[i]
+            }
+        }
+        SharedKeys {
+            y: shared_key.y.clone(),
+            x_i: new_xi,
+        }
+    }
+}
+
+pub struct LocalSig {
+    pub gamma_i: FE,
+    pub e: FE,
+}
+
+impl LocalSig {
+    pub fn compute(
+        message: &[u8],
+        local_ephemaral_key: &SharedKeys,
+        local_private_key: &SharedKeys,
+    ) -> LocalSig {
+        let beta_i = local_ephemaral_key.x_i.clone();
+        let alpha_i = local_private_key.x_i.clone();
+
+        let e_bn = HSha256::create_hash(&[
+            &local_ephemaral_key.y.x_coor().unwrap(),
+            &local_private_key.y.bytes_compressed_to_big_int(),
+            &BigInt::from(message),
+        ]);
+        let e: FE = ECScalar::from(&e_bn);
+        let gamma_i = beta_i + e.clone() * alpha_i;
+        //   let gamma_i = e.clone() * alpha_i ;
+
+        LocalSig { gamma_i, e }
+    }
+
+    // section 4.2 step 3
+    #[allow(unused_doc_comments)]
+    pub fn verify_local_sigs(
+        gamma_vec: &Vec<LocalSig>,
+        parties_index_vec: &[usize],
+        vss_private_keys: &Vec<VerifiableSS>,
+        vss_ephemeral_keys: &Vec<VerifiableSS>,
+    ) -> Result<(VerifiableSS), Error> {
+        //parties_index_vec is a vector with indices of the parties that are participating and provided gamma_i for this step
+        // test that enough parties are in this round
+        assert!(parties_index_vec.len() > vss_private_keys[0].parameters.threshold);
+
+        // Vec of joint commitments:
+        // n' = num of signers, n - num of parties in keygen
+        // [com0_eph_0,... ,com0_eph_n', e*com0_kg_0, ..., e*com0_kg_n ;
+        // ...  ;
+        // comt_eph_0,... ,comt_eph_n', e*comt_kg_0, ..., e*comt_kg_n ]
+        let comm_vec = (0..vss_private_keys[0].parameters.threshold + 1)
+            .map(|i| {
+                let mut key_gen_comm_i_vec = (0..vss_private_keys.len())
+                    .map(|j| vss_private_keys[j].commitments[i].clone() * &gamma_vec[i].e)
+                    .collect::<Vec<GE>>();
+                let mut eph_comm_i_vec = (0..vss_ephemeral_keys.len())
+                    .map(|j| vss_ephemeral_keys[j].commitments[i].clone())
+                    .collect::<Vec<GE>>();
+                key_gen_comm_i_vec.append(&mut eph_comm_i_vec);
+                let mut comm_i_vec_iter = key_gen_comm_i_vec.iter();
+                let comm_i_0 = comm_i_vec_iter.next().unwrap();
+                comm_i_vec_iter.fold(comm_i_0.clone(), |acc, x| acc + x)
+            })
+            .collect::<Vec<GE>>();
+
+        let vss_sum = VerifiableSS {
+            parameters: vss_ephemeral_keys[0].parameters.clone(),
+            commitments: comm_vec,
+        };
+
+        let g: GE = GE::generator();
+        let correct_ss_verify = (0..parties_index_vec.len())
+            .map(|i| {
+                let gamma_i_g = &g * &gamma_vec[i].gamma_i;
+                vss_sum
+                    .validate_share_public(&gamma_i_g, parties_index_vec[i] + 1)
+                    .is_ok()
+            })
+            .collect::<Vec<bool>>();
+
+        match correct_ss_verify.iter().all(|x| x.clone() == true) {
+            true => Ok(vss_sum),
+            false => Err(InvalidSS),
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Signature {
+    pub sigma: FE,
+    pub v: GE,
+}
+
+impl Signature {
+    pub fn generate(
+        vss_sum_local_sigs: &VerifiableSS,
+        local_sig_vec: &Vec<LocalSig>,
+        parties_index_vec: &[usize],
+        v: GE,
+    ) -> Signature {
+        let gamma_vec = (0..parties_index_vec.len())
+            .map(|i| local_sig_vec[i].gamma_i.clone())
+            .collect::<Vec<FE>>();
+        let reconstruct_limit = vss_sum_local_sigs.parameters.threshold.clone() + 1;
+        let sigma = vss_sum_local_sigs.reconstruct(
+            &parties_index_vec[0..reconstruct_limit.clone()],
+            &gamma_vec[0..reconstruct_limit.clone()],
+        );
+        Signature { sigma, v }
+    }
+
+    pub fn verify(&self, message: &[u8], pubkey_y: &GE) -> Result<(), Error> {
+        let e_bn = HSha256::create_hash(&[
+            &self.v.x_coor().unwrap(),
+            &pubkey_y.bytes_compressed_to_big_int(),
+            &BigInt::from(message),
+        ]);
+        let e: FE = ECScalar::from(&e_bn);
+
+        let g: GE = GE::generator();
+        let sigma_g = g * &self.sigma;
+        let e_y = pubkey_y * &e;
+        let e_y_plus_v = e_y + &self.v;
+
+        if e_y_plus_v == sigma_g {
+            Ok(())
+        } else {
+            Err(InvalidSig)
+        }
+    }
+}

--- a/src/crypto/test_multi_party_schnorr.rs
+++ b/src/crypto/test_multi_party_schnorr.rs
@@ -1,0 +1,177 @@
+#![allow(non_snake_case)]
+/*
+    Multisig Schnorr
+
+    Copyright 2018 by Kzen Networks
+    Copyright 2020 by Chaintope Inc.
+
+    This file is copied from Multisig Schnorr library
+    (https://github.com/KZen-networks/multisig-schnorr)
+
+    Multisig Schnorr is free software: you can redistribute
+    it and/or modify it under the terms of the GNU General Public
+    License as published by the Free Software Foundation, either
+    version 3 of the License, or (at your option) any later version.
+
+    @license GPL-3.0+ <https://github.com/KZen-networks/multisig-schnorr/blob/master/LICENSE>
+*/
+use crate::crypto::multi_party_schnorr::*;
+use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
+use curv::{FE, GE};
+
+#[test]
+#[allow(unused_doc_comments)]
+fn test_t2_n4() {
+    /// this test assumes that in keygen we have n=4 parties and in signing we have 4 parties as well.
+    let t = 2;
+    let n = 4;
+    let key_gen_parties_index_vec: [usize; 4] = [0, 1, 2, 3];
+    let key_gen_parties_points_vec = (0..key_gen_parties_index_vec.len())
+        .map(|i| key_gen_parties_index_vec[i].clone() + 1)
+        .collect::<Vec<usize>>();
+
+    let (_priv_keys_vec, priv_shared_keys_vec, Y, key_gen_vss_vec) =
+        keygen_t_n_parties(t.clone(), n.clone(), &key_gen_parties_points_vec);
+    let parties_index_vec: [usize; 4] = [0, 1, 2, 3];
+    let parties_points_vec = (0..parties_index_vec.len())
+        .map(|i| parties_index_vec[i].clone() + 1)
+        .collect::<Vec<usize>>();
+
+    let (_eph_keys_vec, eph_shared_keys_vec, V, eph_vss_vec) =
+        keygen_t_n_parties(t.clone(), n.clone(), &parties_points_vec);
+    let message: [u8; 4] = [79, 77, 69, 82];
+    let local_sig_vec = (0..n.clone())
+        .map(|i| LocalSig::compute(&message, &eph_shared_keys_vec[i], &priv_shared_keys_vec[i]))
+        .collect::<Vec<LocalSig>>();
+    let verify_local_sig = LocalSig::verify_local_sigs(
+        &local_sig_vec,
+        &parties_index_vec,
+        &key_gen_vss_vec,
+        &eph_vss_vec,
+    );
+
+    assert!(verify_local_sig.is_ok());
+    let vss_sum_local_sigs = verify_local_sig.unwrap();
+    let signature = Signature::generate(&vss_sum_local_sigs, &local_sig_vec, &parties_index_vec, V);
+    let verify_sig = signature.verify(&message, &Y);
+    assert!(verify_sig.is_ok());
+}
+
+#[test]
+#[allow(unused_doc_comments)]
+fn test_t2_n5_sign_with_4() {
+    /// this test assumes that in keygen we have n=4 parties and in signing we have 4 parties, indices 0,1,3,4.
+    let t = 2;
+    let n = 5;
+    /// keygen:
+    let key_gen_parties_index_vec: [usize; 5] = [0, 1, 2, 3, 4];
+    let key_gen_parties_points_vec = (0..key_gen_parties_index_vec.len())
+        .map(|i| key_gen_parties_index_vec[i].clone() + 1)
+        .collect::<Vec<usize>>();
+    let (_priv_keys_vec, priv_shared_keys_vec, Y, key_gen_vss_vec) =
+        keygen_t_n_parties(t.clone(), n.clone(), &key_gen_parties_points_vec);
+    /// signing:
+    let parties_index_vec: [usize; 4] = [0, 1, 3, 4];
+    let parties_points_vec = (0..parties_index_vec.len())
+        .map(|i| parties_index_vec[i].clone() + 1)
+        .collect::<Vec<usize>>();
+    let num_parties = parties_index_vec.len();
+    let (_eph_keys_vec, eph_shared_keys_vec, V, eph_vss_vec) =
+        keygen_t_n_parties(t.clone(), num_parties.clone(), &parties_points_vec);
+    let message: [u8; 4] = [79, 77, 69, 82];
+
+    // each party computes and share a local sig, we collected them here to a vector as each party should do AFTER receiving all local sigs
+    let local_sig_vec = (0..num_parties.clone())
+        .map(|i| {
+            LocalSig::compute(
+                &message,
+                &eph_shared_keys_vec[i],
+                &priv_shared_keys_vec[parties_index_vec[i]],
+            )
+        })
+        .collect::<Vec<LocalSig>>();
+
+    let verify_local_sig = LocalSig::verify_local_sigs(
+        &local_sig_vec,
+        &parties_index_vec,
+        &key_gen_vss_vec,
+        &eph_vss_vec,
+    );
+
+    assert!(verify_local_sig.is_ok());
+    let vss_sum_local_sigs = verify_local_sig.unwrap();
+
+    /// each party / dealer can generate the signature
+    let signature = Signature::generate(&vss_sum_local_sigs, &local_sig_vec, &parties_index_vec, V);
+    let verify_sig = signature.verify(&message, &Y);
+    assert!(verify_sig.is_ok());
+}
+
+pub fn keygen_t_n_parties(
+    t: usize,
+    n: usize,
+    parties: &[usize],
+) -> (Vec<Keys>, Vec<SharedKeys>, GE, Vec<VerifiableSS>) {
+    let parames = Parameters {
+        threshold: t,
+        share_count: n.clone(),
+    };
+    assert_eq!(parties.len(), n.clone());
+    let party_keys_vec = (0..n.clone())
+        .map(|i| Keys::phase1_create(parties[i]))
+        .collect::<Vec<Keys>>();
+
+    let mut bc1_vec = Vec::new();
+    let mut blind_vec = Vec::new();
+    for i in 0..n.clone() {
+        let (bc1, blind) = party_keys_vec[i].phase1_broadcast();
+        bc1_vec.push(bc1);
+        blind_vec.push(blind);
+    }
+
+    let y_vec = (0..n.clone())
+        .map(|i| party_keys_vec[i].y_i.clone())
+        .collect::<Vec<GE>>();
+    let mut y_vec_iter = y_vec.iter();
+    let head = y_vec_iter.next().unwrap();
+    let tail = y_vec_iter;
+    let y_sum = tail.fold(head.clone(), |acc, x| acc + x);
+    let mut vss_scheme_vec = Vec::new();
+    let mut secret_shares_vec = Vec::new();
+    let mut index_vec = Vec::new();
+    for i in 0..n.clone() {
+        let (vss_scheme, secret_shares, index) = party_keys_vec[i]
+            .phase1_verify_com_phase2_distribute(&parames, &blind_vec, &y_vec, &bc1_vec, parties)
+            .expect("invalid key");
+        vss_scheme_vec.push(vss_scheme);
+        secret_shares_vec.push(secret_shares);
+        index_vec.push(index);
+    }
+
+    let party_shares = (0..n.clone())
+        .map(|i| {
+            (0..n.clone())
+                .map(|j| {
+                    let vec_j = &secret_shares_vec[j];
+                    vec_j[i].clone()
+                })
+                .collect::<Vec<FE>>()
+        })
+        .collect::<Vec<Vec<FE>>>();
+
+    let mut shared_keys_vec = Vec::new();
+    for i in 0..n.clone() {
+        let shared_keys = party_keys_vec[i]
+            .phase2_verify_vss_construct_keypair(
+                &parames,
+                &y_vec,
+                &party_shares[i],
+                &vss_scheme_vec,
+                &index_vec[i],
+            )
+            .expect("invalid vss");
+        shared_keys_vec.push(shared_keys);
+    }
+
+    (party_keys_vec, shared_keys_vec, y_sum, vss_scheme_vec)
+}

--- a/src/crypto/test_multi_party_schnorr.rs
+++ b/src/crypto/test_multi_party_schnorr.rs
@@ -184,11 +184,9 @@ use std::borrow::Borrow;
 
 const STR_SECRET1: &str = "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747";
 const STR_SECRET2: &str = "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117";
-const STR_SECRET1C: &str = "12b004fff7f4b69ef8650e767f18f11ede158148b425660723b9f9a66e61f747";
-const STR_SECRET2C: &str = "b524c28b61c9b2c49b2c7dd4c2d75887abb78768c054bd7c01af4029f6c0d117";
 
-fn get_shared_keys(wif: &str) -> SharedKeys {
-    let privkey: FE = ECScalar::from(&BigInt::from_hex(STR_SECRET1));
+fn get_shared_keys(str_secret_key: &str) -> SharedKeys {
+    let privkey: FE = ECScalar::from(&BigInt::from_hex(str_secret_key));
 
     SharedKeys {
         y: &ECPoint::generator() * &privkey,
@@ -242,28 +240,6 @@ fn test_sign() {
         };
         assert!(sign2
             .verify(&msg[..], &get_shared_keys(STR_SECRET2).y)
-            .is_ok());
-
-        let sign1c = {
-            let s = LocalSig::compute(&msg[..], &v, &get_shared_keys(STR_SECRET1C));
-            Signature {
-                sigma: s.gamma_i,
-                v: v.y,
-            }
-        };
-        assert!(sign1c
-            .verify(&msg[..], &get_shared_keys(STR_SECRET1C).y)
-            .is_ok());
-
-        let sign2c = {
-            let s = LocalSig::compute(&msg[..], &v, &get_shared_keys(STR_SECRET2C));
-            Signature {
-                sigma: s.gamma_i,
-                v: v.y,
-            }
-        };
-        assert!(sign2c
-            .verify(&msg[..], &get_shared_keys(STR_SECRET2C).y)
             .is_ok());
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,7 +16,9 @@ pub enum Error {
     DuplicatedMessage,
     InvalidLocalSignature,
     InvalidAggregatedSignature,
-    InvalidSignature(secp256k1::Error),
+    InvalidKey,
+    InvalidSS,
+    InvalidSig,
     TimerAlreadyStarted,
     InvalidTomlFormat(toml::de::Error),
     ConfigFileIOError(std::io::Error),
@@ -43,12 +45,6 @@ impl From<jsonrpc::error::Error> for Error {
 impl From<serde_json::error::Error> for Error {
     fn from(e: serde_json::error::Error) -> Error {
         Error::Json(e)
-    }
-}
-
-impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error {
-        Error::InvalidSignature(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,10 +11,14 @@ extern crate byteorder;
 extern crate hex;
 extern crate redis;
 #[macro_use]
+extern crate serde_derive;
+extern crate serde;
+#[macro_use]
 extern crate lazy_static;
 
 pub mod blockdata;
 pub mod command_args;
+pub mod crypto;
 pub mod errors;
 pub mod net;
 pub mod rpc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate serde_derive;
 extern crate serde;
 #[macro_use]
 extern crate lazy_static;
+extern crate sha2;
 
 pub mod blockdata;
 pub mod command_args;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -2,12 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+use crate::crypto::multi_party_schnorr::*;
 use curv::arithmetic::traits::*;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 use curv::elliptic::curves::traits::*;
 use curv::{BigInt, FE, GE};
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::*;
-use multi_party_schnorr::Error::InvalidSS;
 
 use crate::blockdata::hash::Hash;
 use crate::errors::Error;
@@ -45,7 +44,7 @@ impl Sign {
         params: &Parameters,
         secret_shares: &SharedSecretMap,
         index: &usize,
-    ) -> Result<SharedKeys, multi_party_schnorr::Error> {
+    ) -> Result<SharedKeys, Error> {
         assert_eq!(secret_shares.len(), params.share_count);
 
         let correct_ss = secret_shares
@@ -66,7 +65,7 @@ impl Sign {
                     .fold(FE::zero(), |acc, x| acc + x);
                 Ok(SharedKeys { y, x_i })
             }
-            false => Err(InvalidSS),
+            false => Err(Error::InvalidSS),
         }
     }
 

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -1,5 +1,6 @@
 use crate::blockdata::hash::Hash;
 use crate::blockdata::Block;
+use crate::crypto::multi_party_schnorr::{LocalSig, SharedKeys};
 use crate::net::{
     BlockGenerationRoundMessageType, ConnectionManager, Message, MessageType, SignerID,
 };
@@ -11,7 +12,6 @@ use crate::signer_node::ToVerifiableSS;
 use crate::signer_node::{NodeParameters, SharedSecretMap, ToSharedSecretMap};
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 use curv::FE;
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::{LocalSig, SharedKeys};
 
 pub fn process_blocksig<T, C>(
     sender_id: &SignerID,

--- a/src/signer_node/message_processor/process_blockvss.rs
+++ b/src/signer_node/message_processor/process_blockvss.rs
@@ -1,5 +1,6 @@
 use crate::blockdata::hash::Hash;
 use crate::blockdata::Block;
+use crate::crypto::multi_party_schnorr::SharedKeys;
 use crate::net::{
     BlockGenerationRoundMessageType, ConnectionManager, Message, MessageType, SignerID,
 };
@@ -11,7 +12,6 @@ use crate::util::jacobi;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 use curv::elliptic::curves::traits::ECPoint;
 use curv::{BigInt, FE};
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::SharedKeys;
 
 pub fn process_blockvss<T, C>(
     sender_id: &SignerID,

--- a/src/signer_node/message_processor/process_candidateblock.rs
+++ b/src/signer_node/message_processor/process_candidateblock.rs
@@ -1,4 +1,5 @@
 use crate::blockdata::Block;
+use crate::crypto::multi_party_schnorr::Keys;
 use crate::net::{
     BlockGenerationRoundMessageType, ConnectionManager, Message, MessageType, SignerID,
 };
@@ -9,7 +10,6 @@ use crate::signer_node::{NodeParameters, NodeState};
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE};
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::Keys;
 
 pub fn process_candidateblock<T, C>(
     sender_id: &SignerID,

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -7,6 +7,7 @@ mod node_parameters;
 mod utils;
 
 use crate::blockdata::Block;
+use crate::crypto::multi_party_schnorr::*;
 use crate::net::MessageType::{BlockGenerationRoundMessages, KeyGenerationMessage};
 use crate::net::{
     BlockGenerationRoundMessageType, ConnectionManager, KeyGenerationMessageType, Message,
@@ -24,7 +25,6 @@ use crate::util::*;
 use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 use curv::elliptic::curves::traits::*;
 use curv::{FE, GE};
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::*;
 pub use node_parameters::NodeParameters;
 use redis::ControlFlow;
 use std::collections::BTreeMap;

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -1,8 +1,8 @@
 use super::utils::sender_index;
+use crate::crypto::multi_party_schnorr::Parameters;
 use crate::net::SignerID;
 use crate::rpc::TapyrusApi;
 use bitcoin::{Address, PrivateKey, PublicKey};
-use multi_party_schnorr::protocols::thresholdsig::bitcoin_schnorr::Parameters;
 use std::convert::TryInto;
 use std::sync::Arc;
 


### PR DESCRIPTION
Files changed includes #34, #35, #37 

It is enough to review 2 commits( 0c531b2 and 51df7dc).

It was because the hash function used in compute and verify schnorr signature code receive message as BigInt. You can read more details in #32.

This PR moved multi party schnorr signature cryptography codes from multi_party_schnorr into this repo. Its target is bip-schnorr but our protocol is different from that. So, I copied and we are going to extend it.