### PR TITLE
Fix sighash() in case the block has agg pubkey.

### DIFF
--- a/src/blockdata.rs
+++ b/src/blockdata.rs
@@ -78,21 +78,23 @@ pub mod hash {
 pub struct Block(Vec<u8>);
 
 impl Block {
-    const PROOF_POSITION: usize = 105;
+    const AGG_PUBKEY_POSITION: usize = 105;
 
     pub fn new(data: Vec<u8>) -> Block {
         Block(data)
     }
 
-    /// Length of block header without proof is 105 bytes.
+    /// Length of block header without proof is 105 + len bytes.
     /// Version: 4
     /// hasPrevBlock: 32
     /// hashMerkleRoot: 32
     /// hashImMerkleRoot: 32
     /// time: 4
-    /// length of aggPubkey: 1
+    /// length of aggPubkey (len): 1
+    /// aggPubkey: len
     pub fn get_header_without_proof(&self) -> &[u8] {
-        &self.0[..Self::PROOF_POSITION]
+        let position = Self::AGG_PUBKEY_POSITION + self.get_aggregated_public_key_length();
+        &self.0[..position]
     }
 
     pub fn hex(&self) -> String {
@@ -110,10 +112,10 @@ impl Block {
 
     /// Returns block hash
     pub fn hash(&self) -> hash::SHA256Hash {
-        let header = if self.0[Self::PROOF_POSITION] == 0 {
-            &self.0[..(Self::PROOF_POSITION + 1)] // length byte
+        let header = if self.0[Self::AGG_PUBKEY_POSITION] == 0 {
+            &self.0[..(Self::AGG_PUBKEY_POSITION + 1)] // length byte
         } else {
-            &self.0[..(Self::PROOF_POSITION + 65)] // length byte + signature(64 bytes)
+            &self.0[..(Self::AGG_PUBKEY_POSITION + 65)] // length byte + signature(64 bytes)
         };
 
         let hash = sha256d::Hash::hash(header).into_inner();
@@ -125,9 +127,17 @@ impl Block {
         &self.0
     }
     pub fn add_proof(&self, proof: Vec<u8>) -> Block {
-        let (header, txs) = self.payload().split_at(Self::PROOF_POSITION);
+        let position = Self::AGG_PUBKEY_POSITION + self.get_aggregated_public_key_length();
+        let (header, txs) = self.payload().split_at(position);
         let new_payload = [header, &proof[..], &txs[1..]].concat();
         Block(new_payload)
+    }
+
+    /// the length of aggregated public key.
+    /// return 0 if key is not set in block.
+    /// return 33 if otherwise.
+    fn get_aggregated_public_key_length(&self) -> usize {
+        self.0[Self::AGG_PUBKEY_POSITION - 1] as usize
     }
 }
 
@@ -163,10 +173,22 @@ mod tests {
     use super::*;
 
     const TEST_BLOCK: &str = "010000000000000000000000000000000000000000000000000000000000000000000000c1457ff3e5c527e69858108edf0ff1f49eea9c58d8d37300a164b3b4f8c8c7cef1a2e72770d547feae29f2dd40123a97c580d44fd4493de072416d53331997617b96f05d00403a4c09253c7b583e5260074380c9b99b895f938e37799d326ded984fb707e91fa4df2e0524a4ccf5fe224945b4fb94784b411a760eb730d95402d3383dd7ffdc01010000000100000000000000000000000000000000000000000000000000000000000000000000000022210366262690cbdf648132ce0c088962c6361112582364ede120f3780ab73438fc4bffffffff0100f2052a010000002776a9226d70757956774d32596a454d755a4b72687463526b614a787062715447417346484688ac00000000";
+    const TEST_BLOCK2: &str = "010000000000000000000000000000000000000000000000000000000000000000000000e7c526d0125538b13a50b06465fb8b72120be13fb1142e93aba2aabb2a4f369826c18219f76e4d0ebddbaa9b744837c2ac65b347673695a23c3cc1a2be4141e1427d735e21025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3403a4c09253c7b583e5260074380c9b99b895f938e37799d326ded984fb707e91fa4df2e0524a4ccf5fe224945b4fb94784b411a760eb730d95402d3383dd7ffdc0101000000010000000000000000000000000000000000000000000000000000000000000000000000002221025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3ffffffff0100f2052a010000001976a914834e0737cdb9008db614cd95ec98824e952e3dc588ac00000000";
+    const TEST_BLOCK_WITH_PUBKEY: &str = "010000000000000000000000000000000000000000000000000000000000000000000000e7c526d0125538b13a50b06465fb8b72120be13fb1142e93aba2aabb2a4f369826c18219f76e4d0ebddbaa9b744837c2ac65b347673695a23c3cc1a2be4141e1427d735e21025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3000101000000010000000000000000000000000000000000000000000000000000000000000000000000002221025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3ffffffff0100f2052a010000001976a914834e0737cdb9008db614cd95ec98824e952e3dc588ac00000000";
     const TEST_BLOCK_WITHOUT_PROOF: &str = "010000000000000000000000000000000000000000000000000000000000000000000000c1457ff3e5c527e69858108edf0ff1f49eea9c58d8d37300a164b3b4f8c8c7cef1a2e72770d547feae29f2dd40123a97c580d44fd4493de072416d53331997617b96f05d000001010000000100000000000000000000000000000000000000000000000000000000000000000000000022210366262690cbdf648132ce0c088962c6361112582364ede120f3780ab73438fc4bffffffff0100f2052a010000002776a9226d70757956774d32596a454d755a4b72687463526b614a787062715447417346484688ac00000000";
 
     fn test_block() -> Block {
         let raw_block = hex::decode(TEST_BLOCK).unwrap();
+        Block(raw_block)
+    }
+
+    fn test_block2() -> Block {
+        let raw_block = hex::decode(TEST_BLOCK2).unwrap();
+        Block(raw_block)
+    }
+
+    fn test_block_with_pubkey() -> Block {
+        let raw_block = hex::decode(TEST_BLOCK_WITH_PUBKEY).unwrap();
         Block(raw_block)
     }
 
@@ -183,6 +205,12 @@ mod tests {
         let raw_expect = hex::decode(hex_expect).unwrap();
 
         assert_eq!(block.get_header_without_proof(), &raw_expect[..]);
+
+        let block = test_block_with_pubkey();
+        let hex_expect = "010000000000000000000000000000000000000000000000000000000000000000000000e7c526d0125538b13a50b06465fb8b72120be13fb1142e93aba2aabb2a4f369826c18219f76e4d0ebddbaa9b744837c2ac65b347673695a23c3cc1a2be4141e1427d735e21025700236c2890233592fcef262f4520d22af9160e3d9705855140eb2aa06c35d3";
+        let raw_expect = hex::decode(hex_expect).unwrap();
+
+        assert_eq!(block.get_header_without_proof(), &raw_expect[..]);
     }
 
     #[test]
@@ -191,6 +219,12 @@ mod tests {
         let sig_hex = "403a4c09253c7b583e5260074380c9b99b895f938e37799d326ded984fb707e91fa4df2e0524a4ccf5fe224945b4fb94784b411a760eb730d95402d3383dd7ffdc";
 
         assert_eq!(block.add_proof(hex::decode(sig_hex).unwrap()), test_block());
+
+        let block = test_block_with_pubkey();
+        assert_eq!(
+            block.add_proof(hex::decode(sig_hex).unwrap()),
+            test_block2()
+        );
     }
 
     #[test]


### PR DESCRIPTION
We should support use case where the block has an aggregated public key.

