### PR TITLE
Change to use secp256k1::SecretKey::new() to generate random secret key.

### DIFF
--- a/src/sign.rs
+++ b/src/sign.rs
@@ -139,11 +139,8 @@ fn test_create_key() {
     .unwrap();
     assert_eq!(key.y_i, Secp256k1Point::from_coor(&x, &y));
 
-    // When generate random secret key.
-    // it should not raise any panic and no repetition.
-    let keys: Vec<FE> = (0..10).map(|_| Sign::create_key(1, None).u_i).collect();
-    keys.iter()
-        .any(|i| keys.iter().filter(|j| *i == **j).count() > 1);
+    // When generate random secret key, it should not raise any panic.
+    Sign::create_key(1, None);
 }
 
 #[test]


### PR DESCRIPTION
fix #88

Secp256k1Scalar::new_random() has potential to generate invalid secret key.
