### PR TITLE
Ensure a vector of SignerID would be sorted by compressed 33 bytes format.

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -483,7 +483,7 @@ mod test {
         );
         let carol = SignerID::new(
             PublicKey::from_str(
-                "02a85a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e",
+                "0461cc17fc4755599a903c59b2f2b886824afc1dd746632bb053ca2f4297f4b10fc02b133f1644f0fd64a74a7a6b35f78bf5d3354c0be5bb66d16d8fc499fa2a82",
             )
             .unwrap(),
         );

--- a/src/net.rs
+++ b/src/net.rs
@@ -58,13 +58,17 @@ impl PartialEq for SignerID {
 
 impl PartialOrd for SignerID {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.pubkey.to_bytes().partial_cmp(&other.pubkey.to_bytes())
+        let a = self.pubkey.key.serialize();
+        let b = other.pubkey.key.serialize();
+        PartialOrd::partial_cmp(&a[..], &b[..])
     }
 }
 
 impl Ord for SignerID {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.pubkey.to_bytes().cmp(&other.pubkey.to_bytes())
+        let a = self.pubkey.key.serialize();
+        let b = other.pubkey.key.serialize();
+        Ord::cmp(&a[..], &b[..])
     }
 }
 


### PR DESCRIPTION
It already works like this, if all public key is compressed format. 
This change make it guarantees this behavior.