### PR TITLE
Use current federation to sign block

### DIFF
--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -55,11 +55,9 @@ fn main() {
         &signer_config.public_key(),
         signer_config.federations_file(),
     );
-    let federation = federations.last();
 
     let params = NodeParameters::new(
         signer_config.to_address(),
-        federation.signers().iter().map(|i| i.pubkey).collect(),
         signer_config.public_key(),
         rpc,
         round_duration,

--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -61,7 +61,6 @@ fn main() {
         signer_config.to_address(),
         federation.signers().iter().map(|i| i.pubkey).collect(),
         signer_config.public_key(),
-        federation.nodevss().clone(),
         rpc,
         round_duration,
         general_config.skip_waiting_ibd(),

--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -66,6 +66,7 @@ fn main() {
         rpc,
         round_duration,
         general_config.skip_waiting_ibd(),
+        federations,
     );
 
     let node = &mut SignerNode::new(con, params);

--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -60,7 +60,6 @@ fn main() {
     let params = NodeParameters::new(
         signer_config.to_address(),
         federation.signers().iter().map(|i| i.pubkey).collect(),
-        federation.threshold(),
         signer_config.public_key(),
         federation.nodevss().clone(),
         rpc,

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -10,7 +10,7 @@ use curv::cryptographic_primitives::secret_sharing::feldman_vss::{
 };
 use std::collections::HashSet;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Federations {
     /// The vector of federations. This vector should be sorted by block height.
     federations: Vec<Federation>,

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -25,6 +25,14 @@ impl Federations {
         }
     }
 
+    pub fn get_by_block_height(&self, block_height: u64) -> &Federation {
+        self.federations
+            .iter()
+            .filter(|f| f.block_height <= block_height)
+            .last()
+            .expect("Federations should not be empty.")
+    }
+
     pub fn last(&self) -> &Federation {
         self.federations
             .last()
@@ -254,6 +262,21 @@ mod tests {
     use curv::elliptic::curves::traits::ECScalar;
     use curv::BigInt;
     use std::str::FromStr;
+
+    #[test]
+    fn test_get_by_block_height() {
+        let federation0 = Federation::new(TEST_KEYS.pubkeys()[4], 0, 3, node_vss(0));
+        let federation100 = Federation::new(TEST_KEYS.pubkeys()[4], 100, 3, node_vss(1));
+        let federation200 = Federation::new(TEST_KEYS.pubkeys()[4], 200, 4, node_vss(2));
+        let federations = Federations::new(vec![
+            federation0.clone(),
+            federation100.clone(),
+            federation200.clone(),
+        ]);
+        assert_eq!(federations.get_by_block_height(99).clone(), federation0);
+        assert_eq!(federations.get_by_block_height(100).clone(), federation100);
+        assert_eq!(federations.get_by_block_height(101).clone(), federation100);
+    }
 
     #[test]
     fn test_signers() {

--- a/src/signer_node/message_processor/mod.rs
+++ b/src/signer_node/message_processor/mod.rs
@@ -80,7 +80,7 @@ where
         sharing_params.share_count,
     );
 
-    for i in 0..params.pubkey_list.len() {
+    for i in 0..params.pubkey_list(block_height).len() {
         // Skip broadcasting if it is vss for myself. Just return this.
         if i == self_node_index {
             continue;
@@ -96,7 +96,7 @@ where
             ),
             sender_id: params.signer_id,
             receiver_id: Some(SignerID {
-                pubkey: params.pubkey_list[i],
+                pubkey: params.pubkey_list(block_height)[i],
             }),
         });
     }

--- a/src/signer_node/message_processor/mod.rs
+++ b/src/signer_node/message_processor/mod.rs
@@ -125,8 +125,11 @@ where
         shared_block_secrets.len()
     );
     let block = get_valid_block(prev_state, blockhash)?;
+    let block_height = prev_state.block_height();
+    let federation = params.get_federation_by_block_height(block_height);
+
     Vss::create_local_sig_from_shares(
-        &params.node_secret_share(),
+        &federation.node_secret_share(),
         params.self_node_index + 1,
         shared_block_secrets,
         &block,

--- a/src/signer_node/message_processor/mod.rs
+++ b/src/signer_node/message_processor/mod.rs
@@ -58,12 +58,13 @@ pub fn create_block_vss<T, C>(
     block: Block,
     params: &NodeParameters<T>,
     conman: &C,
+    block_height: u64,
 ) -> (Keys, SharedSecret, SharedSecret)
 where
     T: TapyrusApi,
     C: ConnectionManager,
 {
-    let sharing_params = params.sharing_params();
+    let sharing_params = params.sharing_params(block_height);
 
     let (
         key,

--- a/src/signer_node/message_processor/mod.rs
+++ b/src/signer_node/message_processor/mod.rs
@@ -66,6 +66,8 @@ where
 {
     let sharing_params = params.sharing_params(block_height);
 
+    let self_node_index = params.self_node_index(block_height);
+
     let (
         key,
         vss_scheme_for_positive,
@@ -73,14 +75,14 @@ where
         vss_scheme_for_negative,
         secret_shares_for_negative,
     ) = Vss::create_block_shares(
-        params.self_node_index + 1,
+        self_node_index + 1,
         sharing_params.threshold + 1,
         sharing_params.share_count,
     );
 
     for i in 0..params.pubkey_list.len() {
         // Skip broadcasting if it is vss for myself. Just return this.
-        if i == params.self_node_index {
+        if i == self_node_index {
             continue;
         }
 
@@ -103,11 +105,11 @@ where
         key,
         SharedSecret {
             vss: vss_scheme_for_positive.clone(),
-            secret_share: secret_shares_for_positive[params.self_node_index],
+            secret_share: secret_shares_for_positive[self_node_index],
         },
         SharedSecret {
             vss: vss_scheme_for_negative.clone(),
-            secret_share: secret_shares_for_negative[params.self_node_index],
+            secret_share: secret_shares_for_negative[self_node_index],
         },
     )
 }
@@ -131,7 +133,7 @@ where
 
     Vss::create_local_sig_from_shares(
         &federation.node_secret_share(),
-        params.self_node_index + 1,
+        params.self_node_index(block_height) + 1,
         shared_block_secrets,
         &block,
     )

--- a/src/signer_node/message_processor/process_blockparticipants.rs
+++ b/src/signer_node/message_processor/process_blockparticipants.rs
@@ -35,8 +35,12 @@ where
         NodeState::Member {
             shared_block_secrets: s,
             master_index,
+            block_height,
             ..
-        } => (s, params.get_signer_id_by_index(master_index.clone())),
+        } => (
+            s,
+            params.get_signer_id_by_index(*block_height, master_index.clone()),
+        ),
         _ => return prev_state.clone(),
     };
 

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -87,6 +87,8 @@ where
     let new_signatures = store_received_local_sig(sender_id, signatures, gamma_i, e);
     state_builder.signatures(new_signatures.clone());
 
+    let block_height = prev_state.block_height();
+
     log::trace!(
         "number of signatures: {:?} (threshold: {:?})",
         new_signatures.len(),
@@ -122,14 +124,15 @@ where
         .filter(|(i, ..)| participants.contains(i))
         .collect();
 
+    let federation = params.get_federation_by_block_height(block_height);
     let signature = match Vss::aggregate_and_verify_signature(
         candidate_block,
         new_signatures,
         &params.pubkey_list,
-        &params.node_shared_secrets(),
+        &federation.node_shared_secrets(),
         &block_shared_keys,
         &shared_block_secrets_by_participants,
-        &params.node_secret_share(),
+        &federation.node_secret_share(),
     ) {
         Ok(sig) => sig,
         Err(e) => {

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -34,6 +34,8 @@ where
     #[cfg(feature = "dump")]
     let mut dump_builder = {
         let mut builder = DumpBuilder::default();
+        let federation = params.get_federation_by_block_height(block_height);
+        let node_vss = federation.nodevss();
         builder
             .received(Received {
                 sender: sender_id.clone(),
@@ -42,8 +44,10 @@ where
                 e,
             })
             .public_keys(params.pubkey_list(block_height).clone())
+            .threshold(params.threshold(block_height) as usize)
             .public_key(params.signer_id.pubkey)
-            .prev_state(prev_state.clone());
+            .prev_state(prev_state.clone())
+            .node_vss(node_vss.clone());
         builder
     };
     // extract values from state object.

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -41,8 +41,7 @@ where
             })
             .public_keys(params.pubkey_list.clone())
             .public_key(params.signer_id.pubkey)
-            .prev_state(prev_state.clone())
-            .node_vss(params.node_vss.clone());
+            .prev_state(prev_state.clone());
         builder
     };
     // extract values from state object.
@@ -260,7 +259,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .build();
 
         let next = process_blocksig(
@@ -291,7 +289,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .build();
 
         let next = process_blocksig(
@@ -324,7 +321,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .build();
 
         let next = process_blocksig(
@@ -378,7 +374,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .build();
 
         let next = process_blocksig(
@@ -420,7 +415,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .federations(federations)
             .build();
 
@@ -465,7 +459,6 @@ mod tests {
             .rpc(MockRpc::new())
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .federations(federations)
             .build();
 
@@ -512,7 +505,6 @@ mod tests {
             .rpc(rpc)
             .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
-            .node_vss(dump.node_vss.clone())
             .federations(federations)
             .build();
 

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -29,6 +29,8 @@ where
     T: TapyrusApi,
     C: ConnectionManager,
 {
+    let block_height = prev_state.block_height();
+
     #[cfg(feature = "dump")]
     let mut dump_builder = {
         let mut builder = DumpBuilder::default();
@@ -39,7 +41,7 @@ where
                 gamma_i,
                 e,
             })
-            .public_keys(params.pubkey_list.clone())
+            .public_keys(params.pubkey_list(block_height).clone())
             .public_key(params.signer_id.pubkey)
             .prev_state(prev_state.clone());
         builder
@@ -85,8 +87,6 @@ where
     let new_signatures = store_received_local_sig(sender_id, signatures, gamma_i, e);
     state_builder.signatures(new_signatures.clone());
 
-    let block_height = prev_state.block_height();
-
     log::trace!(
         "number of signatures: {:?} (threshold: {:?})",
         new_signatures.len(),
@@ -126,7 +126,7 @@ where
     let signature = match Vss::aggregate_and_verify_signature(
         candidate_block,
         new_signatures,
-        &params.pubkey_list,
+        &params.pubkey_list(block_height),
         &federation.node_shared_secrets(),
         &block_shared_keys,
         &shared_block_secrets_by_participants,
@@ -257,7 +257,6 @@ mod tests {
         let conman = TestConnectionManager::new();
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .build();
 
@@ -287,7 +286,6 @@ mod tests {
         let conman = TestConnectionManager::new();
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .build();
 
@@ -319,7 +317,6 @@ mod tests {
         let conman = TestConnectionManager::new();
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .build();
 
@@ -372,7 +369,6 @@ mod tests {
         let conman = TestConnectionManager::new();
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .build();
 
@@ -413,7 +409,6 @@ mod tests {
         let federations = Federations::new(federations);
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .federations(federations)
             .build();
@@ -457,7 +452,6 @@ mod tests {
         let federations = Federations::new(federations);
         let params = NodeParametersBuilder::new()
             .rpc(MockRpc::new())
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .federations(federations)
             .build();
@@ -503,7 +497,6 @@ mod tests {
         let federations = Federations::new(federations);
         let params = NodeParametersBuilder::new()
             .rpc(rpc)
-            .pubkey_list(dump.public_keys.clone())
             .public_key(dump.public_key)
             .federations(federations)
             .build();

--- a/src/signer_node/message_processor/process_blockvss.rs
+++ b/src/signer_node/message_processor/process_blockvss.rs
@@ -57,18 +57,19 @@ where
     };
 
     match prev_state {
-        NodeState::Master { participants, .. } => {
+        NodeState::Master {
+            participants,
+            block_height,
+            ..
+        } => {
             let mut state_builder = Master::from_node_state(prev_state.clone());
 
             // Broadcast blockparticipants message when the master haven't broadcast yet and met
             // the threshold.
-            if participants.len() == 0
-                && new_shared_block_secrets.len() >= params.threshold as usize
-            {
-                let participants = select_participants_for_signing(
-                    &new_shared_block_secrets,
-                    params.threshold as usize,
-                );
+            let threshold = params.threshold(*block_height);
+            if participants.len() == 0 && new_shared_block_secrets.len() >= threshold as usize {
+                let participants =
+                    select_participants_for_signing(&new_shared_block_secrets, threshold as usize);
 
                 let shared_block_secrets_by_participants = new_shared_block_secrets
                     .clone()

--- a/src/signer_node/message_processor/process_candidateblock.rs
+++ b/src/signer_node/message_processor/process_candidateblock.rs
@@ -44,7 +44,7 @@ where
             Member::from_node_state(prev_state.clone())
                 .block_key(Some(key.u_i))
                 .candidate_block(Some(block.clone()))
-                .master_index(sender_index(sender_id, &params.pubkey_list))
+                .master_index(sender_index(sender_id, &params.pubkey_list(*block_height)))
                 .insert_shared_block_secrets(
                     params.signer_id.clone(),
                     shared_secret_for_positive,

--- a/src/signer_node/message_processor/process_candidateblock.rs
+++ b/src/signer_node/message_processor/process_candidateblock.rs
@@ -28,7 +28,7 @@ where
     );
 
     match &prev_state {
-        NodeState::Member { .. } => {
+        NodeState::Member { block_height, .. } => {
             if let Err(e) = params.rpc.testproposedblock(&block) {
                 log::warn!(
                     "Received Invalid candidate block sender: {}, {:?}",
@@ -39,7 +39,7 @@ where
             }
 
             let (key, shared_secret_for_positive, shared_secret_for_negative) =
-                create_block_vss(block.clone(), params, conman);
+                create_block_vss(block.clone(), params, conman, *block_height);
 
             Member::from_node_state(prev_state.clone())
                 .block_key(Some(key.u_i))

--- a/src/signer_node/message_processor/process_completedblock.rs
+++ b/src/signer_node/message_processor/process_completedblock.rs
@@ -21,6 +21,7 @@ where
         master_index: master_index(prev_state, params)
             .expect("Previous state getting round complete should have round master"),
         next_master_index: next_master_index(prev_state, params),
+        block_height: prev_state.block_height(),
     }
 }
 

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -385,6 +385,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             _ => match self.current_state {
                 NodeState::Member { block_height, .. } => block_height + 1,
                 NodeState::Master { block_height, .. } => block_height + 1,
+                NodeState::RoundComplete { block_height, .. } => block_height + 1,
                 _ => panic!("current_state is invalid"),
             },
         };

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -390,11 +390,11 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         };
         log::info!(
             "Start next round: self_index={}, master_index={}",
-            self.params.self_node_index,
+            self.params.self_node_index(block_height),
             next_master_index,
         );
 
-        if self.params.self_node_index == next_master_index {
+        if self.params.self_node_index(block_height) == next_master_index {
             self.current_state = self.start_new_round(block_height);
         } else {
             self.current_state = Member::default()
@@ -414,7 +414,7 @@ where
     T: TapyrusApi,
 {
     match state {
-        NodeState::Master { .. } => Some(params.self_node_index),
+        NodeState::Master { .. } => Some(params.self_node_index(state.block_height())),
         NodeState::Member { master_index, .. } => Some(*master_index),
         NodeState::RoundComplete { master_index, .. } => Some(*master_index),
         _ => None,
@@ -427,7 +427,7 @@ where
 {
     let next = match state {
         NodeState::Joining => 0,
-        NodeState::Master { .. } => params.self_node_index + 1,
+        NodeState::Master { .. } => params.self_node_index(state.block_height()) + 1,
         NodeState::Member { master_index, .. } => master_index + 1,
         NodeState::RoundComplete {
             next_master_index, ..

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -434,6 +434,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::federation::Federations;
     use crate::net::{ConnectionManager, ConnectionManagerError, Message, SignerID};
     use crate::rpc::tests::{safety, MockRpc};
     use crate::rpc::TapyrusApi;
@@ -540,6 +541,7 @@ mod tests {
         let private_key = TEST_KEYS.key[0];
         let to_address = address(&private_key);
         let public_key = pubkey_list[0].clone();
+        let federations = Federations::new(vec![]);
 
         let mut params = NodeParameters::new(
             to_address,
@@ -550,6 +552,7 @@ mod tests {
             rpc,
             0,
             true,
+            federations,
         );
         params.round_duration = 0;
         let con = TestConnectionManager::new(publish_count, spy);

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -567,7 +567,6 @@ mod tests {
             to_address,
             pubkey_list,
             public_key,
-            node_vss(0),
             rpc,
             0,
             true,

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -299,8 +299,12 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             receiver_id: None,
         });
 
-        let (keys, shared_secret_for_positive, shared_secret_for_negative) =
-            create_block_vss(block.clone(), &self.params, &self.connection_manager);
+        let (keys, shared_secret_for_positive, shared_secret_for_negative) = create_block_vss(
+            block.clone(),
+            &self.params,
+            &self.connection_manager,
+            block_height,
+        );
 
         Master::default()
             .candidate_block(Some(block))
@@ -449,7 +453,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::federation::Federations;
+    use crate::federation::{Federation, Federations};
     use crate::net::{ConnectionManager, ConnectionManagerError, Message, SignerID};
     use crate::rpc::tests::{safety, MockRpc};
     use crate::rpc::TapyrusApi;
@@ -556,12 +560,12 @@ mod tests {
         let private_key = TEST_KEYS.key[0];
         let to_address = address(&private_key);
         let public_key = pubkey_list[0].clone();
-        let federations = Federations::new(vec![]);
+        let federations =
+            Federations::new(vec![Federation::new(public_key, 0, threshold, node_vss(0))]);
 
         let mut params = NodeParameters::new(
             to_address,
             pubkey_list,
-            threshold,
             public_key,
             node_vss(0),
             rpc,

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -1,7 +1,7 @@
 use super::utils::sender_index;
 use crate::crypto::multi_party_schnorr::{Parameters, SharedKeys};
 use crate::crypto::vss::Vss;
-use crate::federation::Federations;
+use crate::federation::{Federation, Federations};
 use crate::net::SignerID;
 use crate::rpc::TapyrusApi;
 use crate::sign::Sign;
@@ -57,6 +57,10 @@ impl<T: TapyrusApi> NodeParameters<T> {
             node_vss,
             federations,
         }
+    }
+
+    fn get_federation_by_block_height(&self, block_height: u64) -> &Federation {
+        self.federations.get_by_block_height(block_height)
     }
 
     pub fn get_signer_id_by_index(&self, index: usize) -> SignerID {

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -1,6 +1,5 @@
 use super::utils::sender_index;
 use crate::crypto::multi_party_schnorr::Parameters;
-use crate::crypto::vss::Vss;
 use crate::federation::{Federation, Federations};
 use crate::net::SignerID;
 use crate::rpc::TapyrusApi;
@@ -17,7 +16,6 @@ pub struct NodeParameters<T: TapyrusApi> {
     pub self_node_index: usize,
     pub round_duration: u64,
     pub skip_waiting_ibd: bool,
-    pub node_vss: Vec<Vss>,
     federations: Federations,
 }
 
@@ -26,7 +24,6 @@ impl<T: TapyrusApi> NodeParameters<T> {
         to_address: Address,
         pubkey_list: Vec<PublicKey>,
         public_key: PublicKey,
-        node_vss: Vec<Vss>,
         rpc: T,
         round_duration: u64,
         skip_waiting_ibd: bool,
@@ -46,7 +43,6 @@ impl<T: TapyrusApi> NodeParameters<T> {
             self_node_index,
             round_duration,
             skip_waiting_ibd,
-            node_vss,
             federations,
         }
     }

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -1,6 +1,7 @@
 use super::utils::sender_index;
 use crate::crypto::multi_party_schnorr::{Parameters, SharedKeys};
 use crate::crypto::vss::Vss;
+use crate::federation::Federations;
 use crate::net::SignerID;
 use crate::rpc::TapyrusApi;
 use crate::sign::Sign;
@@ -23,6 +24,7 @@ pub struct NodeParameters<T: TapyrusApi> {
     pub round_duration: u64,
     pub skip_waiting_ibd: bool,
     pub node_vss: Vec<Vss>,
+    federations: Federations,
 }
 
 impl<T: TapyrusApi> NodeParameters<T> {
@@ -35,6 +37,7 @@ impl<T: TapyrusApi> NodeParameters<T> {
         rpc: T,
         round_duration: u64,
         skip_waiting_ibd: bool,
+        federations: Federations,
     ) -> NodeParameters<T> {
         let signer_id = SignerID { pubkey: public_key };
 
@@ -52,6 +55,7 @@ impl<T: TapyrusApi> NodeParameters<T> {
             round_duration,
             skip_waiting_ibd,
             node_vss,
+            federations,
         }
     }
 

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -1,4 +1,3 @@
-use super::utils::sender_index;
 use crate::crypto::multi_party_schnorr::Parameters;
 use crate::federation::{Federation, Federations};
 use crate::net::SignerID;
@@ -13,7 +12,6 @@ pub struct NodeParameters<T: TapyrusApi> {
     pub address: Address,
     /// Own Signer ID. Actually it is signer own public key.
     pub signer_id: SignerID,
-    pub self_node_index: usize,
     pub round_duration: u64,
     pub skip_waiting_ibd: bool,
     federations: Federations,
@@ -34,13 +32,11 @@ impl<T: TapyrusApi> NodeParameters<T> {
         let mut pubkey_list = pubkey_list;
         NodeParameters::<T>::sort_publickey(&mut pubkey_list);
 
-        let self_node_index = sender_index(&signer_id, &pubkey_list);
         NodeParameters {
             pubkey_list,
             rpc: Arc::new(rpc),
             address: to_address,
             signer_id,
-            self_node_index,
             round_duration,
             skip_waiting_ibd,
             federations,
@@ -77,6 +73,11 @@ impl<T: TapyrusApi> NodeParameters<T> {
     pub fn threshold(&self, block_height: u64) -> u8 {
         let federation = self.get_federation_by_block_height(block_height);
         federation.threshold()
+    }
+
+    pub fn self_node_index(&self, block_height: u64) -> usize {
+        let federation = self.get_federation_by_block_height(block_height);
+        federation.node_index()
     }
 }
 

--- a/src/signer_node/node_state.rs
+++ b/src/signer_node/node_state.rs
@@ -31,6 +31,7 @@ pub enum NodeState {
         participants: HashSet<SignerID>,
         /// Set true when the round is done.
         round_is_done: bool,
+        block_height: u64,
     },
     Member {
         /// *block_key* is random value for using int the Signature Issuing Protocol.
@@ -52,11 +53,24 @@ pub enum NodeState {
         /// are declared by Master node of the round.
         participants: HashSet<SignerID>,
         master_index: usize,
+        block_height: u64,
     },
     RoundComplete {
         master_index: usize,
         next_master_index: usize,
+        block_height: u64,
     },
+}
+
+impl NodeState {
+    pub fn block_height(&self) -> u64 {
+        match &self {
+            NodeState::Joining => 0,
+            NodeState::Master { block_height, .. } => *block_height,
+            NodeState::Member { block_height, .. } => *block_height,
+            NodeState::RoundComplete { block_height, .. } => *block_height,
+        }
+    }
 }
 
 pub mod builder {
@@ -83,6 +97,7 @@ pub mod builder {
         signatures: BTreeMap<SignerID, (FE, FE)>,
         participants: HashSet<SignerID>,
         round_is_done: bool,
+        block_height: u64,
     }
 
     impl Builder for Master {
@@ -95,6 +110,7 @@ pub mod builder {
                 signatures: self.signatures.clone(),
                 participants: self.participants.clone(),
                 round_is_done: self.round_is_done,
+                block_height: 0,
             }
         }
 
@@ -107,6 +123,7 @@ pub mod builder {
                 signatures,
                 participants,
                 round_is_done,
+                block_height,
             } = state
             {
                 Self {
@@ -117,6 +134,7 @@ pub mod builder {
                     signatures,
                     participants,
                     round_is_done,
+                    block_height,
                 }
             } else {
                 unreachable!(
@@ -136,6 +154,7 @@ pub mod builder {
                 signatures: BTreeMap::new(),
                 participants: HashSet::new(),
                 round_is_done: false,
+                block_height: 0,
             }
         }
     }
@@ -149,6 +168,7 @@ pub mod builder {
             signatures: BTreeMap<SignerID, (FE, FE)>,
             participants: HashSet<SignerID>,
             round_is_done: bool,
+            block_height: u64,
         ) -> Self {
             Self {
                 block_key,
@@ -158,6 +178,7 @@ pub mod builder {
                 signatures,
                 participants,
                 round_is_done,
+                block_height,
             }
         }
 
@@ -224,6 +245,11 @@ pub mod builder {
             self.round_is_done = round_is_done;
             self
         }
+
+        pub fn block_height(&mut self, block_height: u64) -> &mut Self {
+            self.block_height = block_height;
+            self
+        }
     }
 
     pub struct Member {
@@ -233,6 +259,7 @@ pub mod builder {
         candidate_block: Option<Block>,
         participants: HashSet<SignerID>,
         master_index: usize,
+        block_height: u64,
     }
 
     impl Default for Member {
@@ -244,6 +271,7 @@ pub mod builder {
                 candidate_block: None,
                 participants: HashSet::new(),
                 master_index: INITIAL_MASTER_INDEX,
+                block_height: 0,
             }
         }
     }
@@ -257,6 +285,7 @@ pub mod builder {
                 candidate_block: self.candidate_block.clone(),
                 participants: self.participants.clone(),
                 master_index: self.master_index,
+                block_height: self.block_height,
             }
         }
 
@@ -268,6 +297,7 @@ pub mod builder {
                 candidate_block,
                 participants,
                 master_index,
+                block_height,
             } = state
             {
                 Self {
@@ -277,6 +307,7 @@ pub mod builder {
                     candidate_block,
                     participants,
                     master_index,
+                    block_height,
                 }
             } else {
                 unreachable!(
@@ -294,6 +325,7 @@ pub mod builder {
             candidate_block: Option<Block>,
             participants: HashSet<SignerID>,
             master_index: usize,
+            block_height: u64,
         ) -> Self {
             Self {
                 block_key,
@@ -302,6 +334,7 @@ pub mod builder {
                 candidate_block,
                 participants,
                 master_index,
+                block_height,
             }
         }
 
@@ -351,6 +384,11 @@ pub mod builder {
 
         pub fn master_index(&mut self, master_index: usize) -> &mut Self {
             self.master_index = master_index;
+            self
+        }
+
+        pub fn block_height(&mut self, block_height: u64) -> &mut Self {
+            self.block_height = block_height;
             self
         }
     }

--- a/src/tests/helper/mod.rs
+++ b/src/tests/helper/mod.rs
@@ -39,11 +39,13 @@ pub mod test_vectors {
     use crate::blockdata::Block;
     use crate::crypto::multi_party_schnorr::LocalSig;
     use crate::crypto::vss::Vss;
+    use crate::federation::{Federation, Federations};
     use crate::net::SignerID;
     use crate::signer_node::NodeParameters;
     use crate::signer_node::SharedSecret;
     use crate::tests::helper::node_parameters_builder::NodeParametersBuilder;
     use crate::tests::helper::rpc::MockRpc;
+
     use bitcoin::{PrivateKey, PublicKey};
     use curv::{FE, GE};
     use serde_json::Value;
@@ -154,13 +156,19 @@ pub mod test_vectors {
             .collect();
         let threshold = value["threshold"].as_u64().unwrap();
         let public_key = to_public_key(&value["public_key"]);
-
+        let federations = vec![Federation::new(
+            public_key,
+            0,
+            threshold as u8,
+            node_vss.clone(),
+        )];
+        let federations = Federations::new(federations);
         NodeParametersBuilder::new()
             .rpc(rpc)
-            .threshold(threshold as u8)
             .pubkey_list(public_keys.clone())
             .public_key(public_key)
             .node_vss(node_vss)
+            .federations(federations)
             .build()
     }
 }

--- a/src/tests/helper/mod.rs
+++ b/src/tests/helper/mod.rs
@@ -167,7 +167,6 @@ pub mod test_vectors {
             .rpc(rpc)
             .pubkey_list(public_keys.clone())
             .public_key(public_key)
-            .node_vss(node_vss)
             .federations(federations)
             .build()
     }

--- a/src/tests/helper/mod.rs
+++ b/src/tests/helper/mod.rs
@@ -150,10 +150,6 @@ pub mod test_vectors {
             .iter()
             .map(|i| Vss::from_str(i.as_str().unwrap()).unwrap())
             .collect();
-        let public_keys: Vec<PublicKey> = node_vss
-            .iter()
-            .map(|i| i.sender_public_key.clone())
-            .collect();
         let threshold = value["threshold"].as_u64().unwrap();
         let public_key = to_public_key(&value["public_key"]);
         let federations = vec![Federation::new(
@@ -165,7 +161,6 @@ pub mod test_vectors {
         let federations = Federations::new(federations);
         NodeParametersBuilder::new()
             .rpc(rpc)
-            .pubkey_list(public_keys.clone())
             .public_key(public_key)
             .federations(federations)
             .build()

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -1,5 +1,5 @@
 use crate::crypto::vss::Vss;
-use crate::federation::Federations;
+use crate::federation::{Federation, Federations};
 use crate::signer_node::NodeParameters;
 use crate::tests::helper::address;
 use crate::tests::helper::keys::TEST_KEYS;
@@ -9,7 +9,6 @@ use bitcoin::{Address, PublicKey};
 
 pub struct NodeParametersBuilder {
     pubkey_list: Vec<PublicKey>,
-    threshold: u8,
     rpc: Option<MockRpc>,
     address: Address,
     round_duration: u64,
@@ -24,14 +23,18 @@ impl NodeParametersBuilder {
     pub fn new() -> Self {
         Self {
             pubkey_list: TEST_KEYS.pubkeys(),
-            threshold: 3,
             rpc: None,
             address: address(&TEST_KEYS.key[0]),
             round_duration: 0,
             skip_waiting_ibd: true,
             public_key: TEST_KEYS.pubkeys()[2],
             node_vss: node_vss(0),
-            federations: Federations::new(vec![]),
+            federations: Federations::new(vec![Federation::new(
+                TEST_KEYS.pubkeys()[0],
+                0,
+                2,
+                node_vss(0),
+            )]),
         }
     }
 
@@ -39,7 +42,6 @@ impl NodeParametersBuilder {
         NodeParameters::new(
             self.address.clone(),
             self.pubkey_list.clone(),
-            self.threshold,
             self.public_key,
             self.node_vss.clone(),
             self.rpc.take().unwrap_or(MockRpc::new()),
@@ -51,11 +53,6 @@ impl NodeParametersBuilder {
 
     pub fn pubkey_list(&mut self, pubkey_list: Vec<PublicKey>) -> &mut Self {
         self.pubkey_list = pubkey_list;
-        self
-    }
-
-    pub fn threshold(&mut self, threshold: u8) -> &mut Self {
-        self.threshold = threshold;
         self
     }
 
@@ -86,6 +83,11 @@ impl NodeParametersBuilder {
 
     pub fn skip_waiting_ibd(&mut self, skip_waiting_ibd: bool) -> &mut Self {
         self.skip_waiting_ibd = skip_waiting_ibd;
+        self
+    }
+
+    pub fn federations(&mut self, federations: Federations) -> &mut Self {
+        self.federations = federations;
         self
     }
 }

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -1,4 +1,3 @@
-use crate::crypto::vss::Vss;
 use crate::federation::{Federation, Federations};
 use crate::signer_node::NodeParameters;
 use crate::tests::helper::address;
@@ -14,7 +13,6 @@ pub struct NodeParametersBuilder {
     round_duration: u64,
     skip_waiting_ibd: bool,
     public_key: PublicKey,
-    node_vss: Vec<Vss>,
     federations: Federations,
 }
 
@@ -28,7 +26,6 @@ impl NodeParametersBuilder {
             round_duration: 0,
             skip_waiting_ibd: true,
             public_key: TEST_KEYS.pubkeys()[2],
-            node_vss: node_vss(0),
             federations: Federations::new(vec![Federation::new(
                 TEST_KEYS.pubkeys()[0],
                 0,
@@ -43,7 +40,6 @@ impl NodeParametersBuilder {
             self.address.clone(),
             self.pubkey_list.clone(),
             self.public_key,
-            self.node_vss.clone(),
             self.rpc.take().unwrap_or(MockRpc::new()),
             self.round_duration,
             self.skip_waiting_ibd,
@@ -58,11 +54,6 @@ impl NodeParametersBuilder {
 
     pub fn public_key(&mut self, public_key: PublicKey) -> &mut Self {
         self.public_key = public_key;
-        self
-    }
-
-    pub fn node_vss(&mut self, node_vss: Vec<Vss>) -> &mut Self {
-        self.node_vss = node_vss;
         self
     }
 

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -7,7 +7,6 @@ use crate::tests::helper::rpc::MockRpc;
 use bitcoin::{Address, PublicKey};
 
 pub struct NodeParametersBuilder {
-    pubkey_list: Vec<PublicKey>,
     rpc: Option<MockRpc>,
     address: Address,
     round_duration: u64,
@@ -20,7 +19,6 @@ impl NodeParametersBuilder {
     /// Returns instance with default value for test.(it not same with production default)
     pub fn new() -> Self {
         Self {
-            pubkey_list: TEST_KEYS.pubkeys(),
             rpc: None,
             address: address(&TEST_KEYS.key[0]),
             round_duration: 0,
@@ -38,18 +36,12 @@ impl NodeParametersBuilder {
     pub fn build(&mut self) -> NodeParameters<MockRpc> {
         NodeParameters::new(
             self.address.clone(),
-            self.pubkey_list.clone(),
             self.public_key,
             self.rpc.take().unwrap_or(MockRpc::new()),
             self.round_duration,
             self.skip_waiting_ibd,
             self.federations.clone(),
         )
-    }
-
-    pub fn pubkey_list(&mut self, pubkey_list: Vec<PublicKey>) -> &mut Self {
-        self.pubkey_list = pubkey_list;
-        self
     }
 
     pub fn public_key(&mut self, public_key: PublicKey) -> &mut Self {

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -1,4 +1,5 @@
 use crate::crypto::vss::Vss;
+use crate::federation::Federations;
 use crate::signer_node::NodeParameters;
 use crate::tests::helper::address;
 use crate::tests::helper::keys::TEST_KEYS;
@@ -15,6 +16,7 @@ pub struct NodeParametersBuilder {
     skip_waiting_ibd: bool,
     public_key: PublicKey,
     node_vss: Vec<Vss>,
+    federations: Federations,
 }
 
 impl NodeParametersBuilder {
@@ -29,6 +31,7 @@ impl NodeParametersBuilder {
             skip_waiting_ibd: true,
             public_key: TEST_KEYS.pubkeys()[2],
             node_vss: node_vss(0),
+            federations: Federations::new(vec![]),
         }
     }
 
@@ -42,6 +45,7 @@ impl NodeParametersBuilder {
             self.rpc.take().unwrap_or(MockRpc::new()),
             self.round_duration,
             self.skip_waiting_ibd,
+            self.federations.clone(),
         )
     }
 

--- a/src/tests/helper/node_state_builder.rs
+++ b/src/tests/helper/node_state_builder.rs
@@ -17,6 +17,7 @@ impl BuilderForTest for Master {
             BTreeMap::new(),
             HashSet::new(),
             false,
+            0,
         )
     }
 }
@@ -29,6 +30,7 @@ impl BuilderForTest for Member {
             None,
             None,
             HashSet::new(),
+            0,
             0,
         )
     }

--- a/tests/resources/process_blocksig.json
+++ b/tests/resources/process_blocksig.json
@@ -21,6 +21,7 @@
       },
       "prev_state": {
         "Member": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -182,6 +183,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -349,6 +351,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -511,6 +514,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -678,6 +682,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -845,6 +850,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [
@@ -1012,6 +1018,7 @@
       },
       "prev_state": {
         "Master": {
+          "block_height": 100,
           "block_key": "f9b7cd6af4cb156de044cec7f1ab53fcdf701ba840c46970c5b513170082a8d3",
           "shared_block_secrets": {
             "02785a891f323acd6cef0fc509bb14304410595914267c50467e51c87142acbb5e": [


### PR DESCRIPTION
This pull request solves a part of the issue #85.

Use current federation to sign block.
Signers should use proper threshold, public keys, and node_vss which are defined federations-file.
This pull request does not contain the feature that an aggregated public key will be set to block before the federation will change.

