### PR TITLE
snap: adjust libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,3 +26,5 @@ parts:
     plugin: rust
     build-packages:
       - libgmp3-dev
+    stage-packages:
+      - libgmp10


### PR DESCRIPTION
libgmp10 is required run-time.