### PR TITLE
Make tapyrus-signerd possible to start-up if the node is not a member of the current federation.

### DIFF
--- a/src/federation.rs
+++ b/src/federation.rs
@@ -150,7 +150,9 @@ impl Federation {
         self.threshold
     }
     pub fn nodevss(&self) -> &Vec<Vss> {
-        self.nodevss.as_ref().expect("The nodevss must not None, when it's used.")
+        self.nodevss
+            .as_ref()
+            .expect("The nodevss must not None, when it's used.")
     }
     pub fn aggregated_public_key(&self) -> PublicKey {
         self.aggregated_public_key
@@ -198,7 +200,7 @@ impl Federation {
     pub fn validate(&self) -> Result<(), Error> {
         // Skip validation if the signer of the node is not a member of the federation.
         if self.threshold.is_none() && self.nodevss.is_none() {
-            return Ok(())
+            return Ok(());
         }
 
         if self.threshold.is_none() || self.nodevss.is_none() {
@@ -228,7 +230,7 @@ impl Federation {
             return Err(Error::InvalidFederation(Some(self.block_height), "The nodevss has wrong receiver value. All VSS's receiver_public_key should be equal with publish key of the signer who runs the node."));
         }
 
-            // Check all commitment length is correct.
+        // Check all commitment length is correct.
         if let Some(threshold) = self.threshold {
             if self
                 .nodevss()
@@ -243,7 +245,8 @@ impl Federation {
         }
 
         // verify each vss.
-        if Sign::verify_vss_and_construct_key(&self.node_shared_secrets(), &(self.node_index() + 1)).is_err()
+        if Sign::verify_vss_and_construct_key(&self.node_shared_secrets(), &(self.node_index() + 1))
+            .is_err()
         {
             return Err(Error::InvalidFederation(
                 Some(self.block_height),
@@ -257,7 +260,7 @@ impl Federation {
     /// Returns whether the signer who hosts the node is a member of this federation.
     /// It is `true` if the signer is a member.
     pub fn is_member(&self) -> bool {
-        self.threshold.is_none() && self.nodevss.is_none()
+        self.threshold.is_some() && self.nodevss.is_some()
     }
 
     pub fn from(pubkey: PublicKey, ser: SerFederation) -> Self {
@@ -436,9 +439,9 @@ mod tests {
         // the federation has invalid secret share
         let mut federation = valid_federation();
 
-        federation.nodevss.as_mut().unwrap()[0].positive_secret = ECScalar::from(&BigInt::from_hex(
-            "9b77b12bf0ec14c6094be7657a3a3d473077bc3c8b694ead6c1b6d8c5b4e816c",
-        ));
+        federation.nodevss.as_mut().unwrap()[0].positive_secret = ECScalar::from(
+            &BigInt::from_hex("9b77b12bf0ec14c6094be7657a3a3d473077bc3c8b694ead6c1b6d8c5b4e816c"),
+        );
         match federation.validate() {
             Err(Error::InvalidFederation(_, m)) => {
                 assert_eq!(m, "The nodevss includes invalid share.")
@@ -528,7 +531,6 @@ mod tests {
 
         let federations = Federations::from_pubkey_and_toml(&pubkey, toml).unwrap();
         assert_eq!(federations.len(), 2);
-
 
         // toml has federation item which dosen't have required item 'aggregated_public_key'.
         let toml = r#"

--- a/src/signer_node/message_processor/process_blocksig.rs
+++ b/src/signer_node/message_processor/process_blocksig.rs
@@ -410,7 +410,7 @@ mod tests {
             dump.public_key,
             0,
             Some(dump.threshold as u8),
-            dump.node_vss.clone(),
+            Some(dump.node_vss.clone()),
             dump.aggregated_public_key,
         )];
         let federations = Federations::new(federations);
@@ -454,7 +454,7 @@ mod tests {
             dump.public_key,
             0,
             Some(dump.threshold as u8),
-            dump.node_vss.clone(),
+            Some(dump.node_vss.clone()),
             dump.aggregated_public_key,
         )];
         let federations = Federations::new(federations);
@@ -500,7 +500,7 @@ mod tests {
             dump.public_key,
             0,
             Some(dump.threshold as u8),
-            dump.node_vss.clone(),
+            Some(dump.node_vss.clone()),
             dump.aggregated_public_key,
         )];
         let federations = Federations::new(federations);

--- a/src/signer_node/message_processor/process_candidateblock.rs
+++ b/src/signer_node/message_processor/process_candidateblock.rs
@@ -304,14 +304,14 @@ mod tests {
             TEST_KEYS.pubkeys()[4],
             0,
             Some(3),
-            node_vss(0),
+            Some(node_vss(0)),
             TEST_KEYS.aggregated(),
         );
         let federation100 = Federation::new(
             TEST_KEYS.pubkeys()[4],
             100,
             Some(3),
-            node_vss(1),
+            Some(node_vss(1)),
             TEST_KEYS.aggregated(),
         );
         let another_key = PublicKey::from_str(
@@ -322,7 +322,7 @@ mod tests {
             TEST_KEYS.pubkeys()[4],
             200,
             Some(4),
-            node_vss(2),
+            Some(node_vss(2)),
             another_key,
         );
         let federations = Federations::new(vec![

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -609,7 +609,7 @@ mod tests {
             public_key,
             0,
             threshold,
-            node_vss(0),
+            Some(node_vss(0)),
             aggregated_public_key,
         )]);
 

--- a/src/tests/helper/mod.rs
+++ b/src/tests/helper/mod.rs
@@ -159,7 +159,7 @@ pub mod test_vectors {
             public_key,
             0,
             Some(threshold as u8),
-            node_vss.clone(),
+            Some(node_vss.clone()),
             aggregated_public_key,
         )];
         let federations = Federations::new(federations);

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -28,7 +28,7 @@ impl NodeParametersBuilder {
                 TEST_KEYS.pubkeys()[1],
                 0,
                 Some(2),
-                node_vss(0),
+                Some(node_vss(0)),
                 TEST_KEYS.aggregated(),
             )]),
         }


### PR DESCRIPTION
This PR fixes two issues.

1. Reported as issue #117. Fixed  in c0979678008490b6ec3c53c74431d2ae24db81d7
2. Panic if the node receives a message when the node is not a member of the current federation. Fixed in b8064c63ac6ea8e62c4b88daa49e8fd1426f5a66