### PR TITLE
Make round limit configurable

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -60,6 +60,15 @@ This configuration file is for general settings about `tapyrus-signerd` process 
 This is an example file.
 
 ```toml
+[general]
+round-duration = 60
+round-limit = 15
+log-quiet = true
+log-level = "info"
+daemon = true
+pid = "/path/to/tapyrus-signer.pid"
+log-file = "/path/to/tapyrus-signer.log"
+
 [signer]
 to-address = "1Co1dFUN..."
 public-key = "033cfe7fa..."
@@ -74,14 +83,6 @@ rpc-endpoint-pass = "pass"
 [redis]
 redis-host = "127.0.0.1"
 redis-port =  6379
-
-[general]
-round-duration = 5
-log-quiet = true
-log-level = "info"
-daemon = true
-pid = "/path/to/tapyrus-signer.pid"
-log-file = "/path/to/tapyrus-signer.log"
 ```
 
 Here describe each item above.
@@ -93,6 +94,8 @@ Here describe each item above.
 * `round-duration` is round-robin duration time(sec).
 This is optional. The default duration is 60 sec.
 if you want more slowly or quickly block creation, then set more big/small duration time.
+* `round-limit` is time limit for the communication in each round. If the communications for rounds
+spends time more than round limit, the round would be regarded as a failure round and the next round would be started. This is optional, default is 15 sec.
 * `log-quiet` is set `true` to silent of log report.
 This is optional, default false
 * `log-level` is Log Level.

--- a/src/bin/tapyrus-signerd.rs
+++ b/src/bin/tapyrus-signerd.rs
@@ -61,6 +61,7 @@ fn main() {
         signer_config.public_key(),
         rpc,
         round_duration,
+        general_config.round_limit(),
         general_config.skip_waiting_ibd(),
         federations,
     );

--- a/src/command_args.rs
+++ b/src/command_args.rs
@@ -415,7 +415,7 @@ impl<'a> CommandArgs<'a> {
     pub fn general_config(&self) -> GeneralConfig {
         GeneralConfig {
             command_args: GeneralCommandArgs {
-                round_duration: self.matches.value_of(OPTION_NAME_REDIS_HOST),
+                round_duration: self.matches.value_of(OPTION_NAME_ROUND_DURATION),
                 round_limit: self.matches.value_of(OPTION_NAME_ROUND_LIMIT),
                 log_level: self.matches.value_of(OPTION_NAME_LOG_LEVEL),
                 log_quiet: self.matches.is_present(OPTION_NAME_LOG_QUIET),
@@ -594,6 +594,7 @@ fn test_priority_commandline() {
     let matches = get_options().get_matches_from(vec![
         "node",
         "-c=tests/resources/signer_config.toml",
+        "--duration=999",
         "--round-limit=99",
         "-p=033cfe7fa1be58191b9108883543e921d31dc7726e051ee773e0ea54786ce438f8",
         "--federations-file=/tmp/federations.toml",
@@ -632,6 +633,7 @@ fn test_priority_commandline() {
     );
     assert_eq!(args.redis_config().port(), 88888);
 
+    assert_eq!(args.general_config().round_duration(), 999);
     assert_eq!(args.general_config().round_limit(), 99);
     assert_eq!(args.general_config().daemon(), true);
     assert_eq!(args.general_config().pid(), "/tmp/test.pid");

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 /// Round interval.
 pub static ROUND_INTERVAL_DEFAULT_SECS: u64 = 60;
 /// Round time limit delta. Round timeout timer should be little longer than `ROUND_INTERVAL_DEFAULT_SECS`.
-static ROUND_TIMELIMIT_DELTA: u64 = 15;
+pub static ROUND_LIMIT_DEFAULT_SECS: u64 = 15;
 
 pub struct SignerNode<T: TapyrusApi, C: ConnectionManager> {
     connection_manager: C,
@@ -109,7 +109,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
     where
         Self: Sized,
     {
-        let timer_limit = params.round_duration + ROUND_TIMELIMIT_DELTA;
+        let timer_limit = params.round_duration + params.round_limit;
         SignerNode {
             connection_manager,
             params,
@@ -650,7 +650,7 @@ mod tests {
             aggregated_public_key,
         )]));
 
-        let mut params = NodeParameters::new(to_address, public_key, rpc, 0, true, federations);
+        let mut params = NodeParameters::new(to_address, public_key, rpc, 0, 10, true, federations);
         params.round_duration = 0;
         let con = TestConnectionManager::new(publish_count, spy);
         let broadcaster = con.sender.clone();

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -12,6 +12,7 @@ pub struct NodeParameters<T: TapyrusApi> {
     /// Own Signer ID. Actually it is signer own public key.
     pub signer_id: SignerID,
     pub round_duration: u64,
+    pub round_limit: u64,
     pub skip_waiting_ibd: bool,
     federations: Federations,
 }
@@ -22,6 +23,7 @@ impl<T: TapyrusApi> NodeParameters<T> {
         public_key: PublicKey,
         rpc: T,
         round_duration: u64,
+        round_limit: u64,
         skip_waiting_ibd: bool,
         federations: Federations,
     ) -> NodeParameters<T> {
@@ -32,6 +34,7 @@ impl<T: TapyrusApi> NodeParameters<T> {
             address: to_address,
             signer_id,
             round_duration,
+            round_limit,
             skip_waiting_ibd,
             federations,
         }

--- a/src/tests/helper/node_parameters_builder.rs
+++ b/src/tests/helper/node_parameters_builder.rs
@@ -10,6 +10,7 @@ pub struct NodeParametersBuilder {
     rpc: Option<MockRpc>,
     address: Address,
     round_duration: u64,
+    round_limit: u64,
     skip_waiting_ibd: bool,
     public_key: PublicKey,
     federations: Federations,
@@ -22,6 +23,7 @@ impl NodeParametersBuilder {
             rpc: None,
             address: address(&TEST_KEYS.key[4]),
             round_duration: 0,
+            round_limit: 15,
             skip_waiting_ibd: true,
             public_key: TEST_KEYS.pubkeys()[4],
             federations: Federations::new(vec![Federation::new(
@@ -40,6 +42,7 @@ impl NodeParametersBuilder {
             self.public_key,
             self.rpc.take().unwrap_or(MockRpc::new()),
             self.round_duration,
+            self.round_limit,
             self.skip_waiting_ibd,
             self.federations.clone(),
         )
@@ -62,6 +65,11 @@ impl NodeParametersBuilder {
 
     pub fn round_duration(&mut self, round_duration: u64) -> &mut Self {
         self.round_duration = round_duration;
+        self
+    }
+
+    pub fn round_limit(&mut self, round_limit: u64) -> &mut Self {
+        self.round_limit = round_limit;
         self
     }
 

--- a/tests/resources/signer_config_sample.toml
+++ b/tests/resources/signer_config_sample.toml
@@ -16,6 +16,7 @@ redis-port =  16379
 
 [general]
 round-duration = 5 # uint64
+round-limit = 15
 log-quiet = true
 log-level = "debug"
 daemon = true


### PR DESCRIPTION
This pull request solves https://github.com/chaintope/tapyrus-signer/issues/123
We have two ways to configure the round limit:
- Describe "round-limit" parameter in the signer_config.toml.
- Specify "round-limit" parameter as command line arguments.