### PR TITLE
snap: set restart-condition to always

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,9 +13,14 @@ architectures:
 
 apps:
   service:
-    command: tapyrus-signerd
+    command: >-
+      tapyrus-signerd
+      $TAPYRUS_SIGNERD_OPTS
     plugs: [network]
+    environment:
+      HOME: $SNAP_USER_COMMON
     daemon: simple
+    restart-condition: always
   daemon:
     command: tapyrus-signerd
     plugs: [network]


### PR DESCRIPTION
as well as chaintope/tapyrus-core#91. Also, make service command line
argument configurable via TAPYRUS_SIGNERD_OPTS environment variable.

Environment variables for tapyrus-signer service is are to be configured
in /etc/environment.