### PR TITLE
Add a description for `skip-waiting-ibd` option

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -68,6 +68,7 @@ log-level = "info"
 daemon = true
 pid = "/path/to/tapyrus-signer.pid"
 log-file = "/path/to/tapyrus-signer.log"
+skip-waiting-ibd = true
 
 [signer]
 to-address = "1Co1dFUN..."
@@ -107,6 +108,11 @@ Specify the pid file path. This option is enabled when the node got '--daemon' f
 * `log-file`
 Specify where log file export to. This option is enabled when the node got '--daemon' flag.
 If not, logs are put on stdout and stderr.
+* `skip-waiting-ibd` is a flag make signer node don't waiting connected Tapyrus full node finishes Initial Block 
+Download when signer node started. When block creation stopped much time, The status of Tapyrus full node changes to 
+progressing Initial Block Download. In this case, block creation is never resume, because signer node waits the status 
+is back to non-IBD. So you can use this flag to start signer node with ignore tapyrus full node status.
+This is optional, default false.
 
 ### [signer] section
 

--- a/src/command_args.rs
+++ b/src/command_args.rs
@@ -587,6 +587,7 @@ fn test_load_from_file() {
         args.general_config().log_file(),
         "/var/log/tapyrus-signer.log"
     );
+    assert_eq!(args.general_config().skip_waiting_ibd(), true);
 }
 
 #[test]
@@ -607,6 +608,7 @@ fn test_priority_commandline() {
         "--daemon",
         "--pid=/tmp/test.pid",
         "--log-file=/tmp/tapyrus-signer.log",
+        "--skip-waiting-ibd",
     ]);
     let args = CommandArgs::load(matches).unwrap();
 
@@ -638,6 +640,7 @@ fn test_priority_commandline() {
     assert_eq!(args.general_config().daemon(), true);
     assert_eq!(args.general_config().pid(), "/tmp/test.pid");
     assert_eq!(args.general_config().log_file(), "/tmp/tapyrus-signer.log");
+    assert_eq!(args.general_config().skip_waiting_ibd(), true);
 }
 
 #[test]

--- a/tests/resources/signer_config_sample.toml
+++ b/tests/resources/signer_config_sample.toml
@@ -22,3 +22,4 @@ log-level = "debug"
 daemon = true
 pid = "/tmp/tapyrus-signer.pid"
 log-file = "/var/log/tapyrus-signer.log"
+skip-waiting-ibd = true


### PR DESCRIPTION
It was ommited in the documents but exists.