### PR TITLE
snap: quit passing command line arguments via environment variable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,7 +15,7 @@ apps:
   service:
     command: >-
       tapyrus-signerd
-      $TAPYRUS_SIGNERD_OPTS
+      --config $SNAP_USER_COMMON/signer.toml
     plugs: [network]
     environment:
       HOME: $SNAP_USER_COMMON


### PR DESCRIPTION
but set config file path by command line arguments.

Everything should be configured in the config file rather than
overriding by command line arguments. The path of the config file
is the only exception.

----

#132 で `--skip-waiting-ibd` も config ファイルで指定できることがわかったので、必要なオプションはすべて config ファイル内に記述し、サービス起動時コマンドラインオプションからは config ファイルのパスのみを指定することにした。

本来すべての設定はconfigファイルに集約するのが自然で、de6a067903f0bc6b90945d725c98330f082971e5 での対応は `--skip-waiting-ibd` がコマンドラインからしか指定できないと思っていたために入れた間違った対応だった。