### PR TITLE
snap: declare some build dependencies explicitly in build dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,8 @@ parts:
     source: https://github.com/chaintope/tapyrus-signer.git
     plugin: rust
     build-packages:
+      - build-essential
+      - m4
       - libgmp3-dev
     stage-packages:
       - libgmp10


### PR DESCRIPTION
Formerly, some build dependencies such as build-essential are not
necessary however it became necessary at some point.

----

以前は build-essential などのビルドに必要なパッケージは明示的に
列挙しなくてもビルド出来ていたが、いつの時点からか明示的に列挙
しないとビルドに失敗するようになった。