### PR TITLE
Reconnect redis

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -161,7 +161,7 @@ pub trait ConnectionManager {
         message_processor: impl FnMut(Message) -> ControlFlow<()> + Send + 'static,
         id: SignerID,
     ) -> JoinHandle<()>;
-    fn error_handler(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError>;
+    fn take_error(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError>;
 }
 
 #[derive(Debug)]
@@ -355,7 +355,7 @@ impl ConnectionManager for RedisManager {
         self.subscribe(message_processor, id)
     }
 
-    fn error_handler(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
+    fn take_error(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
         self.error_receiver.try_recv()
     }
 }
@@ -387,7 +387,7 @@ mod test {
 
         connection_manager.process_message(message, "channel".to_string());
 
-        match connection_manager.error_handler() {
+        match connection_manager.take_error() {
             Ok(e) => {
                 panic!(e.to_string());
             }

--- a/src/net.rs
+++ b/src/net.rs
@@ -161,6 +161,7 @@ pub trait ConnectionManager {
         message_processor: impl FnMut(Message) -> ControlFlow<()> + Send + 'static,
         id: SignerID,
     ) -> JoinHandle<()>;
+    fn test_connection(&self) -> Result<(), errors::Error>;
     fn take_error(
         &mut self,
     ) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError>;
@@ -218,13 +219,6 @@ impl RedisManager {
             client,
             error_sender: s,
             error_receiver: r,
-        }
-    }
-
-    pub fn test_connection(&self) -> Result<(), errors::Error> {
-        match self.client.get_connection() {
-            Ok(_) => Ok(()),
-            Err(e) => Err(errors::Error::from(e)),
         }
     }
 
@@ -352,6 +346,13 @@ impl ConnectionManager for RedisManager {
     ) -> JoinHandle<()> {
         self.clear_error();
         self.subscribe(message_processor, id)
+    }
+
+    fn test_connection(&self) -> Result<(), errors::Error> {
+        match self.client.get_connection() {
+            Ok(_) => Ok(()),
+            Err(e) => Err(errors::Error::from(e)),
+        }
     }
 
     fn take_error(

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -132,15 +132,6 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
 
         loop {
-            let (sender, receiver): (Sender<Message>, Receiver<Message>) = channel();
-            let closure = move |message: Message| match sender.send(message) {
-                Ok(_) => ControlFlow::Continue,
-                Err(error) => {
-                    log::warn!("Happened error!: {:?}", error);
-                    ControlFlow::Break(())
-                }
-            };
-
             match self.connection_manager.test_connection() {
                 Ok(_) => {
                     log::debug!("Connection is established.");
@@ -151,6 +142,15 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                     continue;
                 }
             }
+
+            let (sender, receiver): (Sender<Message>, Receiver<Message>) = channel();
+            let closure = move |message: Message| match sender.send(message) {
+                Ok(_) => ControlFlow::Continue,
+                Err(error) => {
+                    log::warn!("Happened error!: {:?}", error);
+                    ControlFlow::Break(())
+                }
+            };
 
             let id = self.params.signer_id;
             let handler = self.connection_manager.start(closure, id);

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -165,6 +165,8 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                     None => {}
                 }
 
+                // After process when received message. Get message from receiver,
+                // then change that state in main thread side.
                 self.handle_message(&receiver);
 
                 self.handle_timer();
@@ -184,11 +186,9 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
+    /// Check if the node receives signal.
+    /// if any signal, stop the round timer.
     fn handle_signal(&mut self) -> Option<()> {
-        // After process when received message. Get message from receiver,
-        // then change that state in main thread side.
-        // messageを受け取った後の処理。receiverからmessageを受け取り、
-        // stateの変更はmain thread側で行う。
         match &self.stop_signal {
             Some(ref r) => match r.try_recv() {
                 Ok(_) => {
@@ -209,6 +209,8 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
+    /// Check if the node recieves a new message from other nodes.
+    /// if received, process the received message.
     fn handle_message(&mut self, receiver: &Receiver<Message>) {
         // Receiving message.
         match receiver.try_recv() {
@@ -242,6 +244,8 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
+    /// Check if round timer elapsed
+    /// if elapsed, the node start new round.
     fn handle_timer(&mut self) {
         // Checking whether the time limit of a round exceeds.
         match self.round_timer.receiver.try_recv() {
@@ -257,6 +261,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
+    /// Check connection to redis server.
     fn handle_connection_error(&mut self) -> Option<ConnectionManagerError<C::ERROR>> {
         // Checking network connection error
         match self.connection_manager.take_error() {

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -158,7 +158,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
 
                 self.handle_timer();
 
-                match self.handle_connection() {
+                match self.handle_connection_error() {
                     Some(_) => break,
                     None => {}
                 }
@@ -246,7 +246,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
-    fn handle_connection(&mut self) -> Option<ConnectionManagerError<C::ERROR>> {
+    fn handle_connection_error(&mut self) -> Option<ConnectionManagerError<C::ERROR>> {
         // Checking network connection error
         match self.connection_manager.take_error() {
             Ok(e) => {

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -205,7 +205,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                 Err(TryRecvError::Empty) => {
                     // No new messages. Do nothing.
                 }
-                Err(e) => log::debug!("{:?}", e),
+                Err(e) => log::warn!("Can't receive message: {:?}", e),
             }
 
             // Checking whether the time limit of a round exceeds.
@@ -218,9 +218,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                 Err(TryRecvError::Empty) => {
                     // Still waiting round duration interval. Do nothing.
                 }
-                Err(e) => {
-                    log::debug!("{:?}", e);
-                }
+                Err(e) => log::warn!("Round timer generates an error: {:?}", e),
             }
             // Checking network connection error
             match connection_manager_error_handler {
@@ -233,7 +231,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                     Err(TryRecvError::Empty) => {
                         // No errors.
                     }
-                    Err(e) => log::debug!("{:?}", e),
+                    Err(e) => log::warn!("Connection manager can't send error: {:?}", e),
                 },
                 None => {
                     log::warn!("Failed to get error_handler of connection_manager!");

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -257,7 +257,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
 
     fn handle_connection(&mut self) -> Option<ConnectionManagerError<C::ERROR>> {
         // Checking network connection error
-        match self.connection_manager.error_handler() {
+        match self.connection_manager.take_error() {
             Ok(e) => {
                 log::error!("Connection Manager Error {:?}", e);
                 Some(e)
@@ -642,7 +642,7 @@ mod tests {
                 .unwrap()
         }
 
-        fn error_handler(
+        fn take_error(
             &mut self,
         ) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
             let (_, r) = channel();

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -144,12 +144,6 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             let id = self.params.signer_id;
             let handler = self.connection_manager.start(closure, id);
 
-            log::info!("Start Key generation Protocol");
-            // Idle 5s, before node starts Key Generation Protocol communication.
-            // To avoid that nodes which is late to startup can't receive messages.
-            log::info!("Idle 5 secs... ");
-            std::thread::sleep(Duration::from_secs(5));
-
             // Start First Round
             log::info!("Start block creation rounds.");
             self.start_next_round();
@@ -744,7 +738,7 @@ mod tests {
 
         let ss = stop_signal.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(21)); // 21s = 1 round (15s) + idle time(5s) + 1s
+            thread::sleep(Duration::from_secs(16)); // 16s = 1 round (15s) + 1s
             ss.send(1).unwrap();
         });
         node.start();

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -167,9 +167,8 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                 std::thread::sleep(Duration::from_millis(300));
             }
             log::info!("Wait for join thread {:?}", handler.thread().id());
-            match handler.join() {
-                Ok(_) => {}
-                Err(e) => log::warn!("Failed to join thread {:?}", e),
+            if let Err(e) = handler.join() {
+                log::warn!("Failed to join thread {:?}", e);
             }
         }
     }

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -157,7 +157,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             loop {
                 match self.handle_signal() {
                     Some(()) => return,
-                    None => {},
+                    None => {}
                 }
 
                 self.handle_message(&receiver);
@@ -166,7 +166,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
 
                 match self.handle_connection() {
                     Some(_) => break,
-                    None => {},
+                    None => {}
                 }
 
                 // Wait for next loop 300 ms.
@@ -174,7 +174,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             }
             log::info!("Wait for join thread {:?}", handler.thread().id());
             match handler.join() {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => log::warn!("Failed to join thread {:?}", e),
             }
         }
@@ -196,9 +196,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
                     // Stop signal is empty. Continue to run. Do nothing.
                     None
                 }
-                Err(_) => {
-                    Some(())
-                }
+                Err(_) => Some(()),
             },
             None => {
                 // Stop signal receiver is not set. Do nothing.
@@ -234,7 +232,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
             Err(TryRecvError::Empty) => {
                 // No new messages. Do nothing.
             }
-            Err(e) => { 
+            Err(e) => {
                 log::warn!("Can't receive message: {:?}", e);
             }
         }

--- a/src/tests/helper/net.rs
+++ b/src/tests/helper/net.rs
@@ -1,7 +1,7 @@
 use crate::net::{ConnectionManager, ConnectionManagerError, Message, SignerID};
 use redis::ControlFlow;
 use std::cell::RefCell;
-use std::sync::mpsc::Receiver;
+use std::sync::mpsc::channel;
 use std::thread;
 use std::thread::JoinHandle;
 
@@ -68,7 +68,8 @@ impl ConnectionManager for TestConnectionManager {
         thread::Builder::new().spawn(|| {}).unwrap()
     }
 
-    fn error_handler(&mut self) -> Option<Receiver<ConnectionManagerError<Self::ERROR>>> {
-        None::<Receiver<ConnectionManagerError<crate::errors::Error>>>
+    fn error_handler(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
+        let (_s, r) = channel();
+        r.try_recv()
     }
 }

--- a/src/tests/helper/net.rs
+++ b/src/tests/helper/net.rs
@@ -68,7 +68,9 @@ impl ConnectionManager for TestConnectionManager {
         thread::Builder::new().spawn(|| {}).unwrap()
     }
 
-    fn take_error(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
+    fn take_error(
+        &mut self,
+    ) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
         let (_s, r) = channel();
         r.try_recv()
     }

--- a/src/tests/helper/net.rs
+++ b/src/tests/helper/net.rs
@@ -5,6 +5,8 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::thread::JoinHandle;
 
+use crate::errors;
+
 pub struct TestConnectionManager {
     should_broadcast: Vec<Message>,
     pub broadcasted: RefCell<Vec<Message>>,
@@ -66,6 +68,10 @@ impl ConnectionManager for TestConnectionManager {
 
         // This is for just returns JoinHandle instance.
         thread::Builder::new().spawn(|| {}).unwrap()
+    }
+
+    fn test_connection(&self) -> Result<(), errors::Error> {
+        Ok(())
     }
 
     fn take_error(

--- a/src/tests/helper/net.rs
+++ b/src/tests/helper/net.rs
@@ -68,7 +68,7 @@ impl ConnectionManager for TestConnectionManager {
         thread::Builder::new().spawn(|| {}).unwrap()
     }
 
-    fn error_handler(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
+    fn take_error(&mut self) -> Result<ConnectionManagerError<Self::ERROR>, std::sync::mpsc::TryRecvError> {
         let (_s, r) = channel();
         r.try_recv()
     }


### PR DESCRIPTION
This PR solves #59 

Previous implementation is like this:

```rust
main() {
    connection_manager.start();
    loop {
        // handle incoming message.
        if connection_error {
            panic!()
        }
    }
}
```
This PR changed to add loop to reconnect.

```rust

main() {
    loop {
        connection_manager.start();
        loop {
            // handle incoming message.
           if connection_error {
               break;
           }
        }
    }
}

```
