### PR TITLE
snap: set source-branch to release/v0.4.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,6 +28,7 @@ apps:
 parts:
   tapyrus-signer:
     source: https://github.com/chaintope/tapyrus-signer.git
+    source-branch: release/v0.4.0
     plugin: rust
     build-packages:
       - build-essential


### PR DESCRIPTION
Snap packages for 0.4 tracks should be built from release/v0.4.0 branch.
Specify the target branch explicitly.

Thsi change must not merged into master.