### PR TITLE
New cli command to change federation parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,18 +596,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,8 +966,8 @@ dependencies = [
 
 [[package]]
 name = "tapyrus"
-version = "0.4.5"
-source = "git+https://github.com/chaintope/rust-tapyrus?tag=v0.4.5#02cda49e6e887425991cfd1d5acf214b0506bbd9"
+version = "0.4.7"
+source = "git+https://github.com/chaintope/rust-tapyrus?tag=v0.4.7#982c5bd63304f09837c3a7c467d9d814093f22e0"
 dependencies = [
  "bitcoin_hashes 0.8.0",
  "rug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,7 +967,8 @@ dependencies = [
 [[package]]
 name = "tapyrus"
 version = "0.4.7"
-source = "git+https://github.com/chaintope/rust-tapyrus?tag=v0.4.7#982c5bd63304f09837c3a7c467d9d814093f22e0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d77353a85e490b6492d629ea6abe31b969d2d37c004c28a000c1cab67c7a76"
 dependencies = [
  "bitcoin_hashes 0.8.0",
  "rug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 http = "0.1.17"
-tapyrus = { git = "https://github.com/chaintope/rust-tapyrus", tag = "v0.4.7", features = ["use-serde", "rand"] }
+tapyrus = {version = "0.4.7", features = ["use-serde", "rand"] }
 secp256k1 = "0.15.3"
 log = "0.4.6"
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 http = "0.1.17"
-tapyrus = { git = "https://github.com/chaintope/rust-tapyrus", tag = "v0.4.5", features = ["use-serde", "rand"] }
+tapyrus = { git = "https://github.com/chaintope/rust-tapyrus", tag = "v0.4.7", features = ["use-serde", "rand"] }
 secp256k1 = "0.15.3"
 log = "0.4.6"
 env_logger = "0.9.0"

--- a/src/bin/tapyrus-setup.rs
+++ b/src/bin/tapyrus-setup.rs
@@ -6,6 +6,7 @@ use tapyrus_signer::cli::setup::compute_sig::ComputeSigCommand;
 use tapyrus_signer::cli::setup::create_block_vss::CreateBlockVssCommand;
 use tapyrus_signer::cli::setup::create_key::CreateKeyCommand;
 use tapyrus_signer::cli::setup::create_node_vss::CreateNodeVssCommand;
+use tapyrus_signer::cli::setup::federation_change::RegisterFederationChangeCommand;
 use tapyrus_signer::cli::setup::sign::SignCommand;
 use tapyrus_signer::cli::setup::traits::Response;
 use tapyrus_signer::errors::Error;
@@ -20,6 +21,7 @@ fn main() {
         .subcommand(CreateBlockVssCommand::args())
         .subcommand(SignCommand::args())
         .subcommand(ComputeSigCommand::args())
+        .subcommand(RegisterFederationChangeCommand::args())
         .get_matches();
     let result: Result<Box<dyn Response>, Error> = match matches.subcommand_name() {
         Some("createkey") => CreateKeyCommand::execute(
@@ -48,6 +50,11 @@ fn main() {
         Some("computesig") => ComputeSigCommand::execute(
             matches
                 .subcommand_matches("computesig")
+                .expect("invalid args"),
+        ),
+        Some("federation") => ComputeSigCommand::execute(
+            matches
+                .subcommand_matches("federation")
                 .expect("invalid args"),
         ),
         None => return println!("No subcommand was used"),

--- a/src/bin/tapyrus-setup.rs
+++ b/src/bin/tapyrus-setup.rs
@@ -52,7 +52,7 @@ fn main() {
                 .subcommand_matches("computesig")
                 .expect("invalid args"),
         ),
-        Some("federation") => ComputeSigCommand::execute(
+        Some("federation") => RegisterFederationChangeCommand::execute(
             matches
                 .subcommand_matches("federation")
                 .expect("invalid args"),

--- a/src/cli/setup/federation_change.rs
+++ b/src/cli/setup/federation_change.rs
@@ -1,9 +1,8 @@
-
 use crate::cli::setup::traits::Response;
 
 use crate::errors::Error;
 
-use clap::{App, Arg, ArgMatches, SubCommand, ArgGroup};
+use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -12,7 +11,12 @@ use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 use tapyrus::blockdata::block::XField;
 
-///federation 
+///federation command is used to register/unregister federation change.
+/// When register is invoked it writes a new file with the given parameters.
+/// When unregister is invoked it removes the file with the given parameters.
+///
+/// FILE_NAME: federationchange_<timestamp>.dat"
+/// PATH: WRITE_DIR
 ///
 ///USAGE:
 ///federation [OPTIONS] <change> --height <height> <--aggregated-public-key <aggregated-public-key>|--max-block-size <max-block-size>>
@@ -29,19 +33,18 @@ use tapyrus::blockdata::block::XField;
 ///ARGS:
 ///    <change>    register/unregister federation change [possible values: register, unregister]
 ///
-/// 
-/// FILE_NAME: 
-/// 
-//TODO - change directory
+
+//TODO - change this directory to a runtime directory
 #[cfg(debug_assertions)]
 const WRITE_DIR: &str = "target/debug/data/";
 
 #[cfg(not(debug_assertions))]
 const WRITE_DIR: &str = "target/release/data/";
 
+const FILE_NAME: &str = "federationchange_";
 pub struct RegisterFederationChangeResponse {
-    xfield : XField,
-    height:  u32,
+    xfield: XField,
+    height: u32,
     timestamp: std::time::Duration,
 }
 
@@ -52,27 +55,30 @@ impl RegisterFederationChangeResponse {
             height: height,
             timestamp: match std::time::SystemTime::now().duration_since(UNIX_EPOCH) {
                 Ok(n) => n,
-                Err(_) => Duration::new(0, 0)
-            }
+                Err(_) => Duration::new(0, 0),
+            },
         }
     }
 }
 
 impl std::fmt::Display for RegisterFederationChangeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:>010}{}@{:?}", self.height, self.xfield, self.timestamp)
+        write!(
+            f,
+            "{:>010}{}@{}",
+            self.height,
+            self.xfield,
+            self.timestamp.as_micros()
+        )
     }
 }
 
 impl Response for RegisterFederationChangeResponse {}
 
-
 pub struct RegisterFederationChangeCommand {}
 
 impl<'a> RegisterFederationChangeCommand {
-
     pub fn execute(matches: &ArgMatches) -> Result<Box<dyn Response>, Error> {
-
         let change: &str = matches
             .value_of("change")
             .ok_or(Error::InvalidArgs("register/unregister".to_string()))?;
@@ -91,22 +97,22 @@ impl<'a> RegisterFederationChangeCommand {
         if height == 0 {
             return Err(Error::InvalidArgs(format!("Height must be greater than 0")));
         }
-        
+
         let xfield_public_key: XField = match matches.value_of("aggregated-public-key") {
-                Some(key) =>  match tapyrus::PublicKey::from_str(key) {
-                    Ok(public_key) => XField::AggregatePublicKey(public_key),
-                    Err(_) =>  XField::None,
-                }
-                None => XField::None,
-            };
+            Some(key) => match tapyrus::PublicKey::from_str(key) {
+                Ok(public_key) => XField::AggregatePublicKey(public_key),
+                Err(_) => XField::None,
+            },
+            None => XField::None,
+        };
 
         let xfield_max_block_size: XField = match matches.value_of("max-block-size") {
-                Some(s) => match s.parse::<u32>() {
-                    Ok(x) => XField::MaxBlockSize(x),
-                    Err(_) => XField::None,
-                }
-                None => XField::None,
-            };
+            Some(s) => match s.parse::<u32>() {
+                Ok(x) => XField::MaxBlockSize(x),
+                Err(_) => XField::None,
+            },
+            None => XField::None,
+        };
 
         let resp: RegisterFederationChangeResponse = match (&xfield_public_key, &xfield_max_block_size) {
             (XField::AggregatePublicKey(_), XField::None) =>
@@ -118,19 +124,22 @@ impl<'a> RegisterFederationChangeCommand {
 
         if register {
             RegisterFederationChangeCommand::register(resp)?;
-        }
-        else {
+        } else {
             RegisterFederationChangeCommand::unregister(resp)?;
         }
 
         //empty response
-        Ok(Box::new(RegisterFederationChangeResponse::new(XField::None, height)))
+        Ok(Box::new(RegisterFederationChangeResponse::new(
+            XField::None,
+            height,
+        )))
     }
 
-    pub fn register(resp:RegisterFederationChangeResponse) -> Result<(), Error>{
+    pub fn register(resp: RegisterFederationChangeResponse) -> Result<(), Error> {
         fs::create_dir_all(WRITE_DIR)?;
 
-        let file_path = Path::new(WRITE_DIR).join( format!("federationchange_{:?}.dat", resp.timestamp));
+        let file_path =
+            Path::new(WRITE_DIR).join(format!("{}{}.dat", FILE_NAME, resp.timestamp.as_micros()));
         let mut file = File::create(&file_path)?;
         file.write_all(format!("{}", resp).as_ref())?;
         file.flush()?;
@@ -138,54 +147,54 @@ impl<'a> RegisterFederationChangeCommand {
         Ok(())
     }
 
-    pub fn unregister(_resp:RegisterFederationChangeResponse) -> Result<(), Error>{
+    pub fn unregister(_resp: RegisterFederationChangeResponse) -> Result<(), Error> {
         //TODO: implement
         Ok(())
     }
 
     pub fn args<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("federation").args(&[
-            Arg::with_name("change")
-                .required(true)
-                .takes_value(true)
-                .possible_values(&["register", "unregister"])
-                .help("register/unregister federation change"),
-            Arg::with_name("height")
-                .long("height")
-                .required(true)
-                .takes_value(true)
-                .display_order(99)
-                .help("block height from which the change can be made"),
-            Arg::with_name("aggregated-public-key")
-                .long("aggregated-public-key")
-                .takes_value(true)
-                .display_order(1)
-                .help("aggregated public key of the new federation"),
-            Arg::with_name("max-block-size")
-                .long("max-block-size")
-                .takes_value(true)
-                .display_order(2)
-                .help("max block size of the federation"),
-        ])
-        .group(ArgGroup::with_name("xfield")
-            .args(&["aggregated-public-key", "max-block-size"])
-            .required(true)
-            .multiple(false))
+        SubCommand::with_name("federation")
+            .args(&[
+                Arg::with_name("change")
+                    .required(true)
+                    .takes_value(true)
+                    .possible_values(&["register", "unregister"])
+                    .help("register/unregister federation change"),
+                Arg::with_name("height")
+                    .long("height")
+                    .required(true)
+                    .takes_value(true)
+                    .display_order(99)
+                    .help("block height from which the change can be made"),
+                Arg::with_name("aggregated-public-key")
+                    .long("aggregated-public-key")
+                    .takes_value(true)
+                    .display_order(1)
+                    .help("aggregated public key of the new federation"),
+                Arg::with_name("max-block-size")
+                    .long("max-block-size")
+                    .takes_value(true)
+                    .display_order(2)
+                    .help("max block size of the federation"),
+            ])
+            .group(
+                ArgGroup::with_name("xfield")
+                    .args(&["aggregated-public-key", "max-block-size"])
+                    .required(true)
+                    .multiple(false),
+            )
     }
 }
-
-
-
 
 #[cfg(test)]
 
 mod tests {
     use super::*;
-    use std::fs::DirEntry;
-    use std::process::Command;
     use std::fs;
-    use std::str;
+    use std::fs::DirEntry;
     use std::path::PathBuf;
+    use std::process::Command;
+    use std::str;
 
     #[cfg(debug_assertions)]
     const DIR: &str = "debug/";
@@ -193,43 +202,53 @@ mod tests {
     #[cfg(not(debug_assertions))]
     const DIR: &str = "release/";
 
-    fn check_file(content:String) {
+    fn check_file(content: String) {
         // Check that the file was created
         let contents = match fs::read_dir(WRITE_DIR) {
             Ok(contents) => contents,
-            Err(err) => { panic!("Error: {}", err); }
+            Err(err) => {
+                panic!("Error: {}", err);
+            }
         };
 
         let mut found = false;
         // As these tests run in parallel multiple files are created.
         // SO read all files before concluding failure
         for x in contents {
-            let entry:DirEntry = match x {
+            let entry: DirEntry = match x {
                 Ok(e) => e,
-                Err(err) => { panic!("Error: {}", err); }
+                Err(err) => {
+                    panic!("Error: {}", err);
+                }
             };
             let file_name = entry.file_name();
             let file_name_str = file_name.to_string_lossy().into_owned();
 
-            if file_name_str.starts_with("federationchange_") {
+            if file_name_str.starts_with(FILE_NAME) {
                 let file_path = PathBuf::from(WRITE_DIR).join(&file_name);
 
-                let file_contents =  match fs::read_to_string(&file_path){
+                let file_contents = match fs::read_to_string(&file_path) {
                     Ok(contents) => contents,
-                    Err(err) => {panic!("Error reading file: {}", err);}
+                    Err(err) => {
+                        panic!("Error reading file: {}", err);
+                    }
                 };
-                let line:String = match file_contents.parse() {
+                let line: String = match file_contents.parse() {
                     Ok(contents) => contents,
-                    Err(err) => {panic!("Error parsing: {}", err);}
+                    Err(err) => {
+                        panic!("Error parsing: {}", err);
+                    }
                 };
                 if line.contains(&content) {
-                    found = true; break;
+                    found = true;
+                    break;
                 }
                 continue;
-
             }
         }
-        if found { return; }
+        if found {
+            return;
+        }
         panic!("File not found");
     }
 
@@ -259,7 +278,10 @@ mod tests {
         ]);
         let response = RegisterFederationChangeCommand::execute(&matches);
         assert!(response.is_ok());
-        check_file("00000001000121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61".to_string());
+        check_file(
+            "00000001000121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61"
+                .to_string(),
+        );
     }
 
     #[test]
@@ -331,10 +353,8 @@ mod tests {
         );
     }
 
-
     #[test]
     fn test_execute_fail_register_both() {
-
         let output = Command::new(format!("target/{}/tapyrus-setup", DIR).to_string())
             .arg("federation")
             .arg("register")
@@ -347,13 +367,10 @@ mod tests {
             .output()
             .expect("failed to execute process");
 
-        // Check that the exit status indicates a failure
         assert!(!output.status.success());
-
-        // Optionally, you can check the output message as well
         let stderr_str = str::from_utf8(&output.stderr).unwrap();
-        assert!(stderr_str.contains("cannot be used with one or more of the other specified arguments"));
+        assert!(
+            stderr_str.contains("cannot be used with one or more of the other specified arguments")
+        );
     }
-
-
 }

--- a/src/cli/setup/federation_change.rs
+++ b/src/cli/setup/federation_change.rs
@@ -5,71 +5,95 @@ use crate::errors::Error;
 use clap::{App, Arg, ArgGroup, ArgMatches, SubCommand};
 use std::fs;
 use std::fs::File;
-use std::io::Write;
-use std::path::Path;
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::time::{Duration, UNIX_EPOCH};
+use std::sync::Mutex;
 use tapyrus::blockdata::block::XField;
 
-///federation command is used to register/unregister federation change.
-/// When register is invoked it writes a new file with the given parameters.
-/// When unregister is invoked it removes the file with the given parameters.
-///
-/// FILE_NAME: federationchange_<timestamp>.dat"
-/// PATH: WRITE_DIR
-///
-///USAGE:
-///federation [OPTIONS] <change> --height <height> <--aggregated-public-key <aggregated-public-key>|--max-block-size <max-block-size>>
-///
-///FLAGS:
-///    -h, --help       Prints help information
-///    -V, --version    Prints version information
-///
-///OPTIONS:
-///    --aggregated-public-key <aggregated-public-key>    aggregated public key of the new federation
-///    --max-block-size <max-block-size>                  max block size of the federation
-///    --height <height>                                  block height from which the change can be made
-///
-///ARGS:
-///    <change>    register/unregister federation change [possible values: register, unregister]
-///
+//federation command is used to register/unregister federation change.
+// When register is invoked it writes a new file with the given parameters.
+// When unregister is invoked it removes the file with the given parameters.
+//
+// FILE_NAME: federationchange_<timestamp>.dat"
+// PATH: FEDERATION_CHANGE_FILE
+//
+//USAGE:
+//federation [OPTIONS] <change> --height <height> <--aggregated-public-key <aggregated-public-key>|--max-block-size <max-block-size>>
+//
+//FLAGS:
+//    -h, --help       Prints help information
+//    -V, --version    Prints version information
+//
+//OPTIONS:
+//    --aggregated-public-key <aggregated-public-key>    aggregated public key of the new federation
+//    --max-block-size <max-block-size>                  max block size of the federation
+//    --height <height>                                  block height from which the change can be made
+//
+//ARGS:
+//    <change>    register/unregister federation change [possible values: register, unregister]
+//
 
-//TODO - change this directory to a runtime directory
-#[cfg(debug_assertions)]
-const WRITE_DIR: &str = "target/debug/data/";
-
-#[cfg(not(debug_assertions))]
-const WRITE_DIR: &str = "target/release/data/";
-
-const FILE_NAME: &str = "federationchange_";
-pub struct RegisterFederationChangeResponse {
-    xfield: XField,
-    height: u32,
-    timestamp: std::time::Duration,
+lazy_static! {
+    static ref FEDERATION_CHANGE_FILE: PathBuf = {
+        #[cfg(not(test))]
+        {
+            let home:String = std::env::var("HOME").expect("Failed to get home directory");
+            PathBuf::from(&home).join(".tapyrus_signer").join("federationchange.dat")
+        }
+        #[cfg(test)]
+        {
+            PathBuf::from("./target/federationchange_test.dat")
+        }
+    };
 }
 
-impl RegisterFederationChangeResponse {
-    fn new(xfield: XField, height: u32) -> Self {
-        RegisterFederationChangeResponse {
-            xfield: xfield,
-            height: height,
-            timestamp: match std::time::SystemTime::now().duration_since(UNIX_EPOCH) {
-                Ok(n) => n,
-                Err(_) => Duration::new(0, 0),
-            },
-        }
-    }
+
+//hex encoding of height is 8 bytes
+const HEIGHT_STRING_LEN:usize = 8;
+
+lazy_static! {
+    static ref FILE_LOCK: Mutex<()> = Mutex::new(());
+}
+
+
+#[derive(Clone)]
+pub struct RegisterFederationChangeResponse {
+    height: u32,
+    xfield: XField,
 }
 
 impl std::fmt::Display for RegisterFederationChangeResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{:>010}{}@{}",
+            //<8 bytes height><xfield(1 byte xfieldtype + xfield value)>
+            "{:>0len$x}{}",
             self.height,
             self.xfield,
-            self.timestamp.as_micros()
+            len = HEIGHT_STRING_LEN,
         )
+    }
+}
+
+impl RegisterFederationChangeResponse {
+    pub fn from_str(s: &str) -> Result<Self, Error> {
+        let height_str = &s[0..HEIGHT_STRING_LEN];
+        let height = u32::from_str_radix(height_str, 16)
+            .map_err(|_| Error::RegisterFederationError("Failed to parse height".to_string()))?;
+
+        let xfield = s[HEIGHT_STRING_LEN..].to_string();
+        let xfield = XField::from_str(xfield.as_str())
+            .map_err(|_| Error::RegisterFederationError("Failed to parse xfield".to_string()))?;
+        Ok(Self { height, xfield })
+    }
+
+    fn new(xfield: XField, height: u32) -> Self {
+        RegisterFederationChangeResponse {
+            xfield: xfield,
+            height: height
+        }
     }
 }
 
@@ -81,21 +105,21 @@ impl<'a> RegisterFederationChangeCommand {
     pub fn execute(matches: &ArgMatches) -> Result<Box<dyn Response>, Error> {
         let change: &str = matches
             .value_of("change")
-            .ok_or(Error::InvalidArgs("register/unregister".to_string()))?;
+            .ok_or(Error::RegisterFederationError("register/unregister".to_string()))?;
 
         let register = match change {
             "register" => true,
             "unregister" => false,
-            _ => return Err(Error::InvalidArgs("register/unregister".to_string())),
+            _ => return Err(Error::RegisterFederationError("register/unregister".to_string())),
         };
 
         let height: u32 = matches
             .value_of("height")
             .and_then(|s| s.parse::<u32>().ok())
-            .ok_or(Error::InvalidArgs("height".to_string()))?;
+            .ok_or(Error::RegisterFederationError("height".to_string()))?;
 
         if height == 0 {
-            return Err(Error::InvalidArgs(format!("Height must be greater than 0")));
+            return Err(Error::RegisterFederationError(format!("Height must be greater than 0")));
         }
 
         let xfield_public_key: XField = match matches.value_of("aggregated-public-key") {
@@ -119,35 +143,78 @@ impl<'a> RegisterFederationChangeCommand {
                 RegisterFederationChangeResponse::new(xfield_public_key, height),
             (XField::None, XField::MaxBlockSize(_)) =>
                 RegisterFederationChangeResponse::new(xfield_max_block_size, height),
-            _ => return Err(Error::InvalidArgs(format!("At least one xfield change is expected. Provide either aggregated-public-key or max-block-size"))),
+            _ => return Err(Error::RegisterFederationError(format!("At least one xfield change is expected. Provide either aggregated-public-key or max-block-size"))),
         };
 
         if register {
-            RegisterFederationChangeCommand::register(resp)?;
+            RegisterFederationChangeCommand::register(resp.clone())?;
         } else {
-            RegisterFederationChangeCommand::unregister(resp)?;
+            RegisterFederationChangeCommand::unregister(resp.clone())?;
         }
 
         //empty response
-        Ok(Box::new(RegisterFederationChangeResponse::new(
-            XField::None,
-            height,
-        )))
+        Ok(Box::new(resp))
     }
 
     pub fn register(resp: RegisterFederationChangeResponse) -> Result<(), Error> {
-        fs::create_dir_all(WRITE_DIR)?;
+        // mutex to protect file access until register completes.
+        let _guard = FILE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
-        let file_path =
-            Path::new(WRITE_DIR).join(format!("{}{}.dat", FILE_NAME, resp.timestamp.as_micros()));
-        let mut file = File::create(&file_path)?;
-        file.write_all(format!("{}", resp).as_ref())?;
-        file.flush()?;
+        let file_path = Path::new(&*FEDERATION_CHANGE_FILE);
+
+        let mut xfield_changes = Vec::new();
+
+        if !file_path.exists() {
+            //create file
+            if let Some(parent) = FEDERATION_CHANGE_FILE.parent() {
+                if fs::create_dir_all(parent).is_ok() {
+                    fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .open(&*FEDERATION_CHANGE_FILE)
+                        .map_err(|e| Error::RegisterFederationError(format!("Failed to open file: {}", e)))?;
+                }
+            }
+
+        } else {
+            //open if it exists
+            let file = File::open(&file_path)?;
+            let reader = BufReader::new(file);
+            for line in reader.lines() {
+                let line = line?;
+                match line.len(){
+                    0 => break,
+                    _ => {
+                        if line.len() < HEIGHT_STRING_LEN {
+                            return Err(Error::RegisterFederationError(format!("Invalid line: {}", line)));
+                        }
+                        match RegisterFederationChangeResponse::from_str(&line) {
+                            Ok(field) => xfield_changes.push(field),
+                            Err(e) => return Err(Error::RegisterFederationError(format!("Failed to parse line: {}. Error: {}", line, e))),
+                        }
+                    },
+                }
+            }
+        }
+
+        // sort xfield changes by height
+        xfield_changes.push(resp);
+        xfield_changes.sort_by(|a, b| a.height.cmp(&b.height));
+
+        //open the file fresh for writing
+        let file = OpenOptions::new().write(true).truncate(true).open(file_path)?;
+        let mut writer = std::io::BufWriter::new(file);
+
+        for xfield_change in xfield_changes {
+            writeln!(writer, "{}", xfield_change.to_string())?;
+        }
+        writer.flush()?;
 
         Ok(())
     }
 
-    pub fn unregister(_resp: RegisterFederationChangeResponse) -> Result<(), Error> {
+    pub fn unregister(resp: RegisterFederationChangeResponse) -> Result<(), Error> {
+        let _guard = FILE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         //TODO: implement
         Ok(())
     }
@@ -188,10 +255,14 @@ impl<'a> RegisterFederationChangeCommand {
 
 #[cfg(test)]
 
+fn get_file_debug() -> PathBuf{
+    PathBuf::from(&*FEDERATION_CHANGE_FILE)
+}
+
 mod tests {
+    use crate::errors::Error::RegisterFederationError;
+
     use super::*;
-    use std::fs;
-    use std::fs::DirEntry;
     use std::path::PathBuf;
     use std::process::Command;
     use std::str;
@@ -202,54 +273,24 @@ mod tests {
     #[cfg(not(debug_assertions))]
     const DIR: &str = "release/";
 
-    fn check_file(content: String) {
+    fn check_file(file_path:PathBuf, content: String) -> Result<(), Error>{
+
         // Check that the file was created
-        let contents = match fs::read_dir(WRITE_DIR) {
-            Ok(contents) => contents,
-            Err(err) => {
-                panic!("Error: {}", err);
-            }
+        let file = match File::open(&file_path){
+            Ok(file) => file,
+            Err(e) => {
+                panic!("Failed to open file:{} due to err :{}", file_path.to_string_lossy(), e);
+            },
         };
 
-        let mut found = false;
-        // As these tests run in parallel multiple files are created.
-        // SO read all files before concluding failure
-        for x in contents {
-            let entry: DirEntry = match x {
-                Ok(e) => e,
-                Err(err) => {
-                    panic!("Error: {}", err);
-                }
-            };
-            let file_name = entry.file_name();
-            let file_name_str = file_name.to_string_lossy().into_owned();
+        let reader = BufReader::new(file);
 
-            if file_name_str.starts_with(FILE_NAME) {
-                let file_path = PathBuf::from(WRITE_DIR).join(&file_name);
-
-                let file_contents = match fs::read_to_string(&file_path) {
-                    Ok(contents) => contents,
-                    Err(err) => {
-                        panic!("Error reading file: {}", err);
-                    }
-                };
-                let line: String = match file_contents.parse() {
-                    Ok(contents) => contents,
-                    Err(err) => {
-                        panic!("Error parsing: {}", err);
-                    }
-                };
-                if line.contains(&content) {
-                    found = true;
-                    break;
-                }
-                continue;
+        for line in reader.lines() {
+            if line.expect(format!("line not found in file {}", file_path.to_string_lossy()).as_str()).contains(&content) {
+                return Ok(());
             }
         }
-        if found {
-            return;
-        }
-        panic!("File not found");
+        Err(RegisterFederationError(format!("content not found {}", content)))
     }
 
     #[test]
@@ -278,10 +319,11 @@ mod tests {
         ]);
         let response = RegisterFederationChangeCommand::execute(&matches);
         assert!(response.is_ok());
-        check_file(
-            "00000001000121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61"
+        let res = check_file(get_file_debug(),
+            "000000640121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61"
                 .to_string(),
         );
+        assert!(res.is_ok());
     }
 
     #[test]
@@ -296,7 +338,8 @@ mod tests {
         ]);
         let response = RegisterFederationChangeCommand::execute(&matches);
         assert!(response.is_ok());
-        check_file("000000020002400d0300".to_string());
+        let res = check_file(get_file_debug(), "000000c802400d0300".to_string());
+        assert!(res.is_ok());
     }
 
     #[test]
@@ -313,7 +356,7 @@ mod tests {
         assert!(response.is_err());
         assert_eq!(
             format!("{}", response.err().unwrap()),
-            "InvalidArgs(\"Height must be greater than 0\")"
+            "RegisterFederationError(\"Height must be greater than 0\")"
         );
     }
 
@@ -331,7 +374,7 @@ mod tests {
         assert!(response.is_err());
         assert_eq!(
             format!("{}", response.err().unwrap()),
-            "InvalidArgs(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
+            "RegisterFederationError(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
         );
     }
 
@@ -349,7 +392,7 @@ mod tests {
         assert!(response.is_err());
         assert_eq!(
             format!("{}", response.err().unwrap()),
-            "InvalidArgs(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
+            "RegisterFederationError(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
         );
     }
 
@@ -372,5 +415,79 @@ mod tests {
         assert!(
             stderr_str.contains("cannot be used with one or more of the other specified arguments")
         );
+    }
+
+    #[test]
+    fn test_execute_success_register_multiple() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--aggregated-public-key",
+            "033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61",
+            "--height",
+            "1000",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+        let res = check_file(get_file_debug(), "000003e80121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61".to_string());
+        assert!(res.is_ok());
+
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--max-block-size",
+            "200000",
+            "--height",
+            "3000",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+        let res = check_file(get_file_debug(), "00000bb802400d0300".to_string());
+        assert!(res.is_ok());
+
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--max-block-size",
+            "1000000",
+            "--height",
+            "5000",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+        let res = check_file(get_file_debug(), "000013880240420f00".to_string());
+        assert!(res.is_ok());
+
+    }
+
+
+    #[test]
+    fn test_execute_success_register_parallel() {
+        //this test writes to $HOME/.tapyrus_signer/federationchange.dat file
+        //the file contents are not accessible from test and is not verified.
+
+        let output1 = Command::new(format!("target/{}/tapyrus-setup", DIR).to_string())
+            .arg("federation")
+            .arg("register")
+            .arg("--aggregated-public-key")
+            .arg("033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61")
+            .arg("--height")
+            .arg("300")
+            .output()
+            .expect("failed to execute process");
+
+        let output2 = Command::new(format!("target/{}/tapyrus-setup", DIR).to_string())
+            .arg("federation")
+            .arg("register")
+            .arg("--max-block-size")
+            .arg("800000")
+            .arg("--height")
+            .arg("400")
+            .output()
+            .expect("failed to execute process");
+
+        assert!(output1.status.success());
+        assert!(output2.status.success());
+
     }
 }

--- a/src/cli/setup/federation_change.rs
+++ b/src/cli/setup/federation_change.rs
@@ -134,9 +134,17 @@ impl<'a> RegisterFederationChangeCommand {
             Some(key) => match tapyrus::PublicKey::from_str(key) {
                 Ok(public_key) => match public_key.compressed {
                     true => XField::AggregatePublicKey(public_key),
-                    false => return Err(Error::RegisterFederationError(format!("aggregated-public-key was not compressed"))),
+                    false => {
+                        return Err(Error::RegisterFederationError(format!(
+                            "aggregated-public-key was not compressed"
+                        )))
+                    }
+                },
+                Err(_) => {
+                    return Err(Error::RegisterFederationError(format!(
+                        "aggregated-public-key was invalid"
+                    )))
                 }
-                Err(_) => return Err(Error::RegisterFederationError(format!("aggregated-public-key was invalid"))),
             },
             None => XField::None,
         };
@@ -144,7 +152,11 @@ impl<'a> RegisterFederationChangeCommand {
         let xfield_max_block_size: XField = match matches.value_of("max-block-size") {
             Some(s) => match s.parse::<u32>() {
                 Ok(x) => XField::MaxBlockSize(x),
-                Err(_) => return Err(Error::RegisterFederationError(format!("max-block-size was invalid"))),
+                Err(_) => {
+                    return Err(Error::RegisterFederationError(format!(
+                        "max-block-size was invalid"
+                    )))
+                }
             },
             None => XField::None,
         };

--- a/src/cli/setup/federation_change.rs
+++ b/src/cli/setup/federation_change.rs
@@ -1,0 +1,359 @@
+
+use crate::cli::setup::traits::Response;
+
+use crate::errors::Error;
+
+use clap::{App, Arg, ArgMatches, SubCommand, ArgGroup};
+use std::fs;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::str::FromStr;
+use std::time::{Duration, UNIX_EPOCH};
+use tapyrus::blockdata::block::XField;
+
+///federation 
+///
+///USAGE:
+///federation [OPTIONS] <change> --height <height> <--aggregated-public-key <aggregated-public-key>|--max-block-size <max-block-size>>
+///
+///FLAGS:
+///    -h, --help       Prints help information
+///    -V, --version    Prints version information
+///
+///OPTIONS:
+///    --aggregated-public-key <aggregated-public-key>    aggregated public key of the new federation
+///    --max-block-size <max-block-size>                  max block size of the federation
+///    --height <height>                                  block height from which the change can be made
+///
+///ARGS:
+///    <change>    register/unregister federation change [possible values: register, unregister]
+///
+/// 
+/// FILE_NAME: 
+/// 
+//TODO - change directory
+#[cfg(debug_assertions)]
+const WRITE_DIR: &str = "target/debug/data/";
+
+#[cfg(not(debug_assertions))]
+const WRITE_DIR: &str = "target/release/data/";
+
+pub struct RegisterFederationChangeResponse {
+    xfield : XField,
+    height:  u32,
+    timestamp: std::time::Duration,
+}
+
+impl RegisterFederationChangeResponse {
+    fn new(xfield: XField, height: u32) -> Self {
+        RegisterFederationChangeResponse {
+            xfield: xfield,
+            height: height,
+            timestamp: match std::time::SystemTime::now().duration_since(UNIX_EPOCH) {
+                Ok(n) => n,
+                Err(_) => Duration::new(0, 0)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for RegisterFederationChangeResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:>010}{}@{:?}", self.height, self.xfield, self.timestamp)
+    }
+}
+
+impl Response for RegisterFederationChangeResponse {}
+
+
+pub struct RegisterFederationChangeCommand {}
+
+impl<'a> RegisterFederationChangeCommand {
+
+    pub fn execute(matches: &ArgMatches) -> Result<Box<dyn Response>, Error> {
+
+        let change: &str = matches
+            .value_of("change")
+            .ok_or(Error::InvalidArgs("register/unregister".to_string()))?;
+
+        let register = match change {
+            "register" => true,
+            "unregister" => false,
+            _ => return Err(Error::InvalidArgs("register/unregister".to_string())),
+        };
+
+        let height: u32 = matches
+            .value_of("height")
+            .and_then(|s| s.parse::<u32>().ok())
+            .ok_or(Error::InvalidArgs("height".to_string()))?;
+
+        if height == 0 {
+            return Err(Error::InvalidArgs(format!("Height must be greater than 0")));
+        }
+        
+        let xfield_public_key: XField = match matches.value_of("aggregated-public-key") {
+                Some(key) =>  match tapyrus::PublicKey::from_str(key) {
+                    Ok(public_key) => XField::AggregatePublicKey(public_key),
+                    Err(_) =>  XField::None,
+                }
+                None => XField::None,
+            };
+
+        let xfield_max_block_size: XField = match matches.value_of("max-block-size") {
+                Some(s) => match s.parse::<u32>() {
+                    Ok(x) => XField::MaxBlockSize(x),
+                    Err(_) => XField::None,
+                }
+                None => XField::None,
+            };
+
+        let resp: RegisterFederationChangeResponse = match (&xfield_public_key, &xfield_max_block_size) {
+            (XField::AggregatePublicKey(_), XField::None) =>
+                RegisterFederationChangeResponse::new(xfield_public_key, height),
+            (XField::None, XField::MaxBlockSize(_)) =>
+                RegisterFederationChangeResponse::new(xfield_max_block_size, height),
+            _ => return Err(Error::InvalidArgs(format!("At least one xfield change is expected. Provide either aggregated-public-key or max-block-size"))),
+        };
+
+        if register {
+            RegisterFederationChangeCommand::register(resp)?;
+        }
+        else {
+            RegisterFederationChangeCommand::unregister(resp)?;
+        }
+
+        //empty response
+        Ok(Box::new(RegisterFederationChangeResponse::new(XField::None, height)))
+    }
+
+    pub fn register(resp:RegisterFederationChangeResponse) -> Result<(), Error>{
+        fs::create_dir_all(WRITE_DIR)?;
+
+        let file_path = Path::new(WRITE_DIR).join( format!("federationchange_{:?}.dat", resp.timestamp));
+        let mut file = File::create(&file_path)?;
+        file.write_all(format!("{}", resp).as_ref())?;
+        file.flush()?;
+
+        Ok(())
+    }
+
+    pub fn unregister(_resp:RegisterFederationChangeResponse) -> Result<(), Error>{
+        //TODO: implement
+        Ok(())
+    }
+
+    pub fn args<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("federation").args(&[
+            Arg::with_name("change")
+                .required(true)
+                .takes_value(true)
+                .possible_values(&["register", "unregister"])
+                .help("register/unregister federation change"),
+            Arg::with_name("height")
+                .long("height")
+                .required(true)
+                .takes_value(true)
+                .display_order(99)
+                .help("block height from which the change can be made"),
+            Arg::with_name("aggregated-public-key")
+                .long("aggregated-public-key")
+                .takes_value(true)
+                .display_order(1)
+                .help("aggregated public key of the new federation"),
+            Arg::with_name("max-block-size")
+                .long("max-block-size")
+                .takes_value(true)
+                .display_order(2)
+                .help("max block size of the federation"),
+        ])
+        .group(ArgGroup::with_name("xfield")
+            .args(&["aggregated-public-key", "max-block-size"])
+            .required(true)
+            .multiple(false))
+    }
+}
+
+
+
+
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+    use std::fs::DirEntry;
+    use std::process::Command;
+    use std::fs;
+    use std::str;
+    use std::path::PathBuf;
+
+    #[cfg(debug_assertions)]
+    const DIR: &str = "debug/";
+
+    #[cfg(not(debug_assertions))]
+    const DIR: &str = "release/";
+
+    fn check_file(content:String) {
+        // Check that the file was created
+        let contents = match fs::read_dir(WRITE_DIR) {
+            Ok(contents) => contents,
+            Err(err) => { panic!("Error: {}", err); }
+        };
+
+        let mut found = false;
+        // As these tests run in parallel multiple files are created.
+        // SO read all files before concluding failure
+        for x in contents {
+            let entry:DirEntry = match x {
+                Ok(e) => e,
+                Err(err) => { panic!("Error: {}", err); }
+            };
+            let file_name = entry.file_name();
+            let file_name_str = file_name.to_string_lossy().into_owned();
+
+            if file_name_str.starts_with("federationchange_") {
+                let file_path = PathBuf::from(WRITE_DIR).join(&file_name);
+
+                let file_contents =  match fs::read_to_string(&file_path){
+                    Ok(contents) => contents,
+                    Err(err) => {panic!("Error reading file: {}", err);}
+                };
+                let line:String = match file_contents.parse() {
+                    Ok(contents) => contents,
+                    Err(err) => {panic!("Error parsing: {}", err);}
+                };
+                if line.contains(&content) {
+                    found = true; break;
+                }
+                continue;
+
+            }
+        }
+        if found { return; }
+        panic!("File not found");
+    }
+
+    #[test]
+    fn test_execute_success_unregister() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "unregister",
+            "--aggregated-public-key",
+            "033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61",
+            "--height",
+            "500",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+    }
+
+    #[test]
+    fn test_execute_success_register_pubkey() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--aggregated-public-key",
+            "033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61",
+            "--height",
+            "100",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+        check_file("00000001000121033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61".to_string());
+    }
+
+    #[test]
+    fn test_execute_success_register_maxblockize() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--max-block-size",
+            "200000",
+            "--height",
+            "200",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_ok());
+        check_file("000000020002400d0300".to_string());
+    }
+
+    #[test]
+    fn test_execute_fail_register_height() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--aggregated-public-key",
+            "033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61",
+            "--height",
+            "0",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_err());
+        assert_eq!(
+            format!("{}", response.err().unwrap()),
+            "InvalidArgs(\"Height must be greater than 0\")"
+        );
+    }
+
+    #[test]
+    fn test_execute_fail_register_pubkey() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--aggregated-public-key",
+            "033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61000000",
+            "--height",
+            "60",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_err());
+        assert_eq!(
+            format!("{}", response.err().unwrap()),
+            "InvalidArgs(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
+        );
+    }
+
+    #[test]
+    fn test_execute_fail_register_maxblocksize() {
+        let matches = RegisterFederationChangeCommand::args().get_matches_from(vec![
+            "federation",
+            "register",
+            "--max-block-size",
+            "t",
+            "--height",
+            "700",
+        ]);
+        let response = RegisterFederationChangeCommand::execute(&matches);
+        assert!(response.is_err());
+        assert_eq!(
+            format!("{}", response.err().unwrap()),
+            "InvalidArgs(\"At least one xfield change is expected. Provide either aggregated-public-key or max-block-size\")"
+        );
+    }
+
+
+    #[test]
+    fn test_execute_fail_register_both() {
+
+        let output = Command::new(format!("target/{}/tapyrus-setup", DIR).to_string())
+            .arg("federation")
+            .arg("register")
+            .arg("--aggregated-public-key")
+            .arg("033e6e1d4ae3e7e1bc2173e2af1f2f65c6284ea7c6478f2241784c77b0dff98e61")
+            .arg("--max-block-size")
+            .arg("9000")
+            .arg("--height")
+            .arg("900")
+            .output()
+            .expect("failed to execute process");
+
+        // Check that the exit status indicates a failure
+        assert!(!output.status.success());
+
+        // Optionally, you can check the output message as well
+        let stderr_str = str::from_utf8(&output.stderr).unwrap();
+        assert!(stderr_str.contains("cannot be used with one or more of the other specified arguments"));
+    }
+
+
+}

--- a/src/cli/setup/mod.rs
+++ b/src/cli/setup/mod.rs
@@ -13,6 +13,7 @@ pub mod compute_sig;
 pub mod create_block_vss;
 pub mod create_key;
 pub mod create_node_vss;
+pub mod federation_change;
 pub mod sign;
 pub mod traits;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,8 @@ pub enum Error {
     InvalidAggregatedPublicKey,
     /// xField is not supported by signer.
     UnsupportedXField,
+    /// Error when federation change command is unsuccessful.
+    RegisterFederationError(String),
 }
 
 impl std::fmt::Display for Error {


### PR DESCRIPTION
New command with name **federation** is added to register or unregister changes in the federation.
Only register is implemented in the PR. Register creates a file named `federationchange.dat` with the given xfield parameters in the directory `$HOME/.tapyrus_signer`. 
`federationchange.dat` file contains all pending xfield changes encoded in hex and sorted by height  _`<height><xfield>`_
tests use the file path _./target/federationchange_test.dat_
