### PR TITLE
Change block height from u64 to u32 like tapyrus-core

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// Errors for using incomplete block(like no proof block) as usual block.
     IncompleteBlock,
     /// Errors when the federation is invalid. This error has the block height of the federation gets started and message string.
-    InvalidFederation(Option<u64>, &'static str),
+    InvalidFederation(Option<u32>, &'static str),
     /// Error when the aggregated public key included the candidate block is invalid.
     InvalidAggregatedPublicKey,
     /// xField is not supported by signer.

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -25,7 +25,7 @@ impl Federations {
         }
     }
 
-    pub fn get_by_block_height(&self, block_height: u64) -> &Federation {
+    pub fn get_by_block_height(&self, block_height: u32) -> &Federation {
         self.federations
             .iter()
             .filter(|f| f.block_height <= block_height)
@@ -52,7 +52,7 @@ impl Federations {
         }
 
         // Check the block
-        let unique_block_height: HashSet<u64> =
+        let unique_block_height: HashSet<u32> =
             self.federations.iter().map(|i| i.block_height).collect();
         if unique_block_height.len() != self.federations.len() {
             return Err(Error::InvalidFederation(
@@ -95,7 +95,7 @@ pub struct Federation {
     /// If the block height is 100, the aggregated public key of this federation is set at 99 height
     /// block. Then from the next block which height is 100, Tapyrus network would get started to
     /// use new aggreted public key to verify blocks.
-    block_height: u64,
+    block_height: u32,
     /// The threshold which is requirement number of signer's agreements to produce block signatures.
     /// This field must be None when the signer is not a member of the federation.
     threshold: Option<u8>,
@@ -109,7 +109,7 @@ pub struct Federation {
 impl Federation {
     pub fn new(
         public_key: PublicKey,
-        block_height: u64,
+        block_height: u32,
         threshold: Option<u8>,
         nodevss: Option<Vec<Vss>>,
         aggregated_public_key: PublicKey,
@@ -143,7 +143,7 @@ impl Federation {
         signers
     }
 
-    pub fn block_height(&self) -> u64 {
+    pub fn block_height(&self) -> u32 {
         self.block_height
     }
     pub fn threshold(&self) -> Option<u8> {
@@ -291,7 +291,7 @@ pub struct SerFederations {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SerFederation {
     #[serde(rename = "block-height")]
-    block_height: u64,
+    block_height: u32,
     threshold: Option<u8>,
     #[serde(rename = "node-vss")]
     nodevss: Option<Vec<Vss>>,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -14,7 +14,7 @@ use tapyrus::consensus::encode::{deserialize, serialize};
 #[derive(Debug, Deserialize, Clone)]
 pub struct GetBlockchainInfoResult {
     pub chain: String,
-    pub blocks: u64,
+    pub blocks: u32,
     pub headers: u64,
     pub bestblockhash: String,
     pub mediantime: u64,

--- a/src/signer_node/message_processor/mod.rs
+++ b/src/signer_node/message_processor/mod.rs
@@ -58,7 +58,7 @@ pub fn create_block_vss<T, C>(
     block: Block,
     params: &NodeParameters<T>,
     conman: &C,
-    block_height: u64,
+    block_height: u32,
 ) -> (Keys, SharedSecret, SharedSecret)
 where
     T: TapyrusApi,

--- a/src/signer_node/message_processor/process_candidateblock.rs
+++ b/src/signer_node/message_processor/process_candidateblock.rs
@@ -68,7 +68,7 @@ where
 
 fn verify_block<T>(
     block: &Block,
-    block_height: u64,
+    block_height: u32,
     params: &NodeParameters<T>,
 ) -> Result<(), Error>
 where
@@ -83,7 +83,7 @@ where
 
 fn verify_aggregated_public_key<T>(
     block: &Block,
-    block_height: u64,
+    block_height: u32,
     params: &NodeParameters<T>,
 ) -> Result<(), Error>
 where

--- a/src/signer_node/mod.rs
+++ b/src/signer_node/mod.rs
@@ -338,13 +338,13 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         }
     }
 
-    fn start_new_round(&mut self, block_height: u64) -> NodeState {
+    fn start_new_round(&mut self, block_height: u32) -> NodeState {
         self.round_interval_timer.restart().unwrap();
         Master::default().block_height(block_height).build()
     }
 
     /// A master node of the round starts a round communication with sending candidateblock message.
-    pub fn start_round_communication(&mut self, block_height: u64) -> NodeState {
+    pub fn start_round_communication(&mut self, block_height: u32) -> NodeState {
         let block = match self.params.rpc.getnewblock(&self.params.address) {
             Ok(block) => block,
             Err(e) => {
@@ -397,7 +397,7 @@ impl<T: TapyrusApi, C: ConnectionManager> SignerNode<T, C> {
         federation.signers().contains(signer_id)
     }
 
-    fn add_aggregated_public_key_if_needed(&self, block_height: u64, mut block: Block) -> Block {
+    fn add_aggregated_public_key_if_needed(&self, block_height: u32, mut block: Block) -> Block {
         let next_block_height = block_height + 1;
         let federation = self
             .params
@@ -561,7 +561,7 @@ where
 fn next_master_index<T>(
     state: &NodeState,
     params: &NodeParameters<T>,
-    target_block_height: u64,
+    target_block_height: u32,
 ) -> usize
 where
     T: TapyrusApi,

--- a/src/signer_node/node_parameters.rs
+++ b/src/signer_node/node_parameters.rs
@@ -40,17 +40,17 @@ impl<T: TapyrusApi> NodeParameters<T> {
         }
     }
 
-    pub fn get_federation_by_block_height(&self, block_height: u64) -> &Federation {
+    pub fn get_federation_by_block_height(&self, block_height: u32) -> &Federation {
         self.federations.get_by_block_height(block_height)
     }
 
-    pub fn get_signer_id_by_index(&self, block_height: u64, index: usize) -> SignerID {
+    pub fn get_signer_id_by_index(&self, block_height: u32, index: usize) -> SignerID {
         SignerID {
             pubkey: self.pubkey_list(block_height)[index].clone(),
         }
     }
 
-    pub fn sharing_params(&self, block_height: u64) -> Parameters {
+    pub fn sharing_params(&self, block_height: u32) -> Parameters {
         let t = (self.threshold(block_height) - 1 as u8).try_into().unwrap();
         let n: usize = (self.pubkey_list(block_height).len() as u8)
             .try_into()
@@ -69,24 +69,24 @@ impl<T: TapyrusApi> NodeParameters<T> {
         });
     }
 
-    pub fn threshold(&self, block_height: u64) -> u8 {
+    pub fn threshold(&self, block_height: u32) -> u8 {
         let federation = self.get_federation_by_block_height(block_height);
         federation
             .threshold()
             .expect("threshold should not be None")
     }
 
-    pub fn self_node_index(&self, block_height: u64) -> usize {
+    pub fn self_node_index(&self, block_height: u32) -> usize {
         let federation = self.get_federation_by_block_height(block_height);
         federation.node_index()
     }
 
-    pub fn pubkey_list(&self, block_height: u64) -> Vec<PublicKey> {
+    pub fn pubkey_list(&self, block_height: u32) -> Vec<PublicKey> {
         let federation = self.get_federation_by_block_height(block_height);
         federation.signers().iter().map(|s| s.pubkey).collect()
     }
 
-    pub fn aggregated_public_key(&self, block_height: u64) -> PublicKey {
+    pub fn aggregated_public_key(&self, block_height: u32) -> PublicKey {
         let federation = self.get_federation_by_block_height(block_height);
         federation.aggregated_public_key()
     }

--- a/src/signer_node/node_state.rs
+++ b/src/signer_node/node_state.rs
@@ -14,7 +14,7 @@ pub enum NodeState {
     /// federation in past block height.
     Idling {
         /// A height at the block which is the next block of the tip.
-        block_height: u64,
+        block_height: u32,
     },
     Master {
         /// *block_key* is random value for using int the Signature Issuing Protocol.
@@ -40,7 +40,7 @@ pub enum NodeState {
         participants: HashSet<SignerID>,
         /// Set true when the round is done.
         round_is_done: bool,
-        block_height: u64,
+        block_height: u32,
     },
     Member {
         /// *block_key* is random value for using int the Signature Issuing Protocol.
@@ -62,16 +62,16 @@ pub enum NodeState {
         /// are declared by Master node of the round.
         participants: HashSet<SignerID>,
         master_index: usize,
-        block_height: u64,
+        block_height: u32,
     },
     RoundComplete {
         master_index: usize,
-        block_height: u64,
+        block_height: u32,
     },
 }
 
 impl NodeState {
-    pub fn block_height(&self) -> u64 {
+    pub fn block_height(&self) -> u32 {
         match &self {
             NodeState::Idling { block_height } => *block_height,
             NodeState::Master { block_height, .. } => *block_height,
@@ -106,7 +106,7 @@ pub mod builder {
         signatures: BTreeMap<SignerID, (FE, FE)>,
         participants: HashSet<SignerID>,
         round_is_done: bool,
-        block_height: u64,
+        block_height: u32,
     }
 
     impl Builder for Master {
@@ -177,7 +177,7 @@ pub mod builder {
             signatures: BTreeMap<SignerID, (FE, FE)>,
             participants: HashSet<SignerID>,
             round_is_done: bool,
-            block_height: u64,
+            block_height: u32,
         ) -> Self {
             Self {
                 block_key,
@@ -255,7 +255,7 @@ pub mod builder {
             self
         }
 
-        pub fn block_height(&mut self, block_height: u64) -> &mut Self {
+        pub fn block_height(&mut self, block_height: u32) -> &mut Self {
             self.block_height = block_height;
             self
         }
@@ -268,7 +268,7 @@ pub mod builder {
         candidate_block: Option<Block>,
         participants: HashSet<SignerID>,
         master_index: usize,
-        block_height: u64,
+        block_height: u32,
     }
 
     impl Default for Member {
@@ -334,7 +334,7 @@ pub mod builder {
             candidate_block: Option<Block>,
             participants: HashSet<SignerID>,
             master_index: usize,
-            block_height: u64,
+            block_height: u32,
         ) -> Self {
             Self {
                 block_key,
@@ -396,7 +396,7 @@ pub mod builder {
             self
         }
 
-        pub fn block_height(&mut self, block_height: u64) -> &mut Self {
+        pub fn block_height(&mut self, block_height: u32) -> &mut Self {
             self.block_height = block_height;
             self
         }


### PR DESCRIPTION
As we encode block_height in coinable transaction 'vin[0].prevout.n' block height needs to be u32. Tapyrus-core uses uint32_t.  