### PR TITLE
Fix ci error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
       matrix:
         feature: ["", "--features \"dump\""]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-serialize"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "ryu"
@@ -966,8 +966,9 @@ dependencies = [
 
 [[package]]
 name = "tapyrus"
-version = "0.4.5"
-source = "git+https://github.com/chaintope/rust-tapyrus?tag=v0.4.5#02cda49e6e887425991cfd1d5acf214b0506bbd9"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1869b2bde899d49cbc7b5e041768051e560ddc6acc4d7755d6d94b4a470cfc93"
 dependencies = [
  "bitcoin_hashes 0.8.0",
  "rug",
@@ -997,6 +998,7 @@ dependencies = [
  "log",
  "redis",
  "regex",
+ "rustc-serialize",
  "secp256k1 0.15.5",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ derive_builder = "0.9.0"
 gmp-mpfr-sys = "1.4.8"
 regex = "1.5.6"
 generic-array = "0.12.4"
+rustc-serialize = {version = "0.3.25"}
 
 [features]
 dump = []

--- a/tests/tapyrus-signer.rs
+++ b/tests/tapyrus-signer.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2019 Chaintope Inc.
 
+//! This is the documentation for the tapyrus-signer test module.
+//! It provides tests for the tapyrus-signer crate.
 #![deny(warnings, missing_docs)]
 
 extern crate tapyrus_signer;


### PR DESCRIPTION
This RP fix:

* Add missing documentation since rust 1.83 fixed an issue where missing_docs was not being applied during testing.
* Update rustc-serialize version to resolve rustc-serialize lifetime error
* Bump actions/checkout and actions/cache version to v4