### PR TITLE
Fix release build: skip gmp-mpfr-sys self-test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ libc = "0.2.66"
 daemonize = "0.4.1"
 lazy_static = "1.4.0"
 derive_builder = "0.9.0"
-gmp-mpfr-sys = "1.4.8"
+gmp-mpfr-sys = { version = "1.4.8", features = ["c-no-tests"] }
 regex = "1.5.6"
 generic-array = "0.12.4"
 rustc-serialize = {version = "0.3.25"}


### PR DESCRIPTION

gmp-mpfr-sys vendors and builds GMP from source, running GMP's own test suite as part of the build; that self-test segfaults/aborts on Apple Silicon. Add the c-no-tests feature to skip it -- we only need GMP to build and link, not pass its own test suite.

Verified: cargo build --release succeeds and produces working tapyrus-setup/tapyrus-signerd binaries. No toolchain pin needed here -- master already carries the rustc-serialize 0.3.25 bump that fixes the separate rustc 1.76+ lifetime-checking regression.